### PR TITLE
Get JSON transactions as a Generator

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -210,15 +210,18 @@ class Mint(requests.Session):
         interface.  Note that the CSV transactions never exclude duplicates.
 
         """
-        
-        return list(self.get_transactions_json_generator(include_investment=include_investment, skip_duplicates=skip_duplicates))
+
+        return list(
+            self.get_transactions_json_generator(
+                include_investment=include_investment,
+                skip_duplicates=skip_duplicates))
 
     def get_transactions_json_generator(self, include_investment=False,
-                              skip_duplicates=False):
-        """Returns a generator for the raw JSON transaction data as downloaded from Mint.  The JSON
-        transaction data includes some additional information missing from the
-        CSV data, such as whether the transaction is pending or completed, but
-        leaves off the year.
+                                        skip_duplicates=False):
+        """Returns a generator for the raw JSON transaction data as downloaded
+        from Mint.  The JSON transaction data includes some additional
+        information missing from the CSV data, such as whether the transaction
+        is pending or completed, but leaves off the year.
 
         Warning: In order to reliably include or exclude duplicates, it is
         necessary to change the user account property 'hide_duplicates' to the


### PR DESCRIPTION
This is a very simple change that includes a method, `get_transactions_json_generator`. This method is almost exactly the same as the original `get_transactions_json`, but returns a generator instead.

I also refactored the `get_transactions_json` method to use this new generator, and return a `list(...)` of it, preserving the exact functionality.

This gave me a nice performance boost for many tasks that require just the very recent history of my transactions!
