### PR TITLE
chore: Add stale.yml configuration file for stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: ['awaiting-feedback']
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not recieved 
+  an answer to a collaborator's question. It will be closed if no further activity
+  occurs. Thank you for your contributions.


### PR DESCRIPTION
* This configuration will mark 'awaiting-feedback' labeled issues or pull requests with a stale label
if no one responds to the issue/PR within 60 days. It will then close it after 7 after the label if no futher activity results.

Fixes #285