### PR TITLE
fix: :bug: Fix but where mintapi leaves chrome instances if there is an error in sign in

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -629,7 +629,8 @@ class Mint(object):
             wait_for_sync_timeout=wait_for_sync_timeout,
             use_chromedriver_on_path=use_chromedriver_on_path,
             chromedriver_download_path=chromedriver_download_path)
-        self.token = self.get_token()
+        if self.driver is not None:  # check if sign in failed
+            self.token = self.get_token()
 
     def get_token(self):
         value_json = self.driver.find_element_by_name(

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -439,26 +439,31 @@ def get_web_driver(email, password, headless=False, mfa_method=None, mfa_token=N
     driver = _create_web_driver_at_mint_com(
         headless, session_path, use_chromedriver_on_path, chromedriver_download_path)
 
-    _sign_in(email, password, driver, mfa_method, mfa_token, mfa_input_callback, intuit_account, wait_for_sync, wait_for_sync_timeout, imap_account,
-             imap_password, imap_server, imap_folder)
-
-    # Wait until the overview page has actually loaded, and if wait_for_sync==True, sync has completed.
     status_message = None
-    if wait_for_sync:
-        try:
-            # Status message might not be present straight away. Seems to be due
-            # to dynamic content (client side rendering).
-            status_message = WebDriverWait(driver, 30).until(
-                expected_conditions.visibility_of_element_located(
-                    (By.CSS_SELECTOR, ".SummaryView .message")))
-            WebDriverWait(driver, wait_for_sync_timeout).until(
-                lambda x: "Account refresh complete" in status_message.get_attribute('innerHTML')
-            )
-        except (TimeoutException, StaleElementReferenceException):
-            logger.warning("Mint sync apparently incomplete after timeout. "
-                           "Data retrieved may not be current.")
-    else:
-        driver.find_element_by_id("transaction")
+    try:
+        _sign_in(email, password, driver, mfa_method, mfa_token, mfa_input_callback, intuit_account, wait_for_sync, wait_for_sync_timeout, imap_account,
+                 imap_password, imap_server, imap_folder)
+
+        # Wait until the overview page has actually loaded, and if wait_for_sync==True, sync has completed.
+        if wait_for_sync:
+            try:
+                # Status message might not be present straight away. Seems to be due
+                # to dynamic content (client side rendering).
+                status_message = WebDriverWait(driver, 30).until(
+                    expected_conditions.visibility_of_element_located(
+                        (By.CSS_SELECTOR, ".SummaryView .message")))
+                WebDriverWait(driver, wait_for_sync_timeout).until(
+                    lambda x: "Account refresh complete" in status_message.get_attribute('innerHTML')
+                )
+            except (TimeoutException, StaleElementReferenceException):
+                logger.warning("Mint sync apparently incomplete after timeout. "
+                               "Data retrieved may not be current.")
+        else:
+            driver.find_element_by_id("transaction")
+    except Exception as e:
+        logger.exception(e)
+        driver.quit()
+        driver = None
 
     if status_message is not None and isinstance(status_message, WebElement):
         status_message = status_message.text

--- a/mintapi/tests.py
+++ b/mintapi/tests.py
@@ -101,6 +101,15 @@ class MintApiTests(unittest.TestCase):
         transactions_df = mint.get_transactions()
         assert(isinstance(transactions_df, pd.DataFrame))
 
+    @patch.object(mintapi.api, '_create_web_driver_at_mint_com')
+    @patch.object(mintapi.api, 'logger')
+    @patch.object(mintapi.api, '_sign_in')
+    def test_when_sign_in_fails_then_logs_exception(self, mock_sign_in, mock_logger, *_):
+        test_exception = Exception()
+        mock_sign_in.side_effect = test_exception
+        mintapi.Mint('test', 'test')
+        mock_logger.exception.assert_called_with(test_exception)
+
 
 @unittest.skipIf(test_args is None, "This test requires a sign in")
 class GivenBrowserAtSignInPage(unittest.TestCase):


### PR DESCRIPTION
* Wraps sign in and wait-for-sync with a try-except and close driver on exception

Fixes #190

This is a re-write of the stale pull request #220. I thought that that pull request had too many refactors built into the code and was too far behind the main branch that the pull request became confusing. This PR should be simpler but still have the core fix.