### PR TITLE
bump version to 1.52 to deploy new URL to pypi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.52
+---
+- No changes. Redeploy to pypi to update project URLs (github#292)
+
 1.51
 ---
 - don't leave dangling chrome instances on sign-in exception

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     name='mintapi',
     description='a screen-scraping API for Mint.com',
     long_description="https://github.com/mintapi/mintapi/",
-    version='1.51',
+    version='1.52',
     packages=['mintapi'],
     license='The MIT License',
     author='Michael Rooney',


### PR DESCRIPTION
The setup.py has the new URL, so we have to deploy to pypi so it knows about it!