### PR TITLE
require selenium-requests>=1.3.3 in setup.py for pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     author='Michael Rooney',
     author_email='mrooney.mintapi@rowk.com',
     url='https://github.com/mintapi/mintapi',
-    install_requires=['future', 'mock', 'requests', 'selenium-requests', 'xmltodict', 'pandas>=1.0', 'selenium', 'oathtool'],
+    install_requires=['future', 'mock', 'requests', 'selenium-requests>=1.3.3', 'xmltodict', 'pandas>=1.0', 'selenium', 'oathtool'],
     entry_points=dict(
         console_scripts=[
             'mintapi = mintapi.api:main',


### PR DESCRIPTION
This should ensure you get the latest selenium-requests when pip installing as well: https://packaging.python.org/discussions/install-requires-vs-requirements/.