### PR TITLE
release version 1.53 w/ actual selenium-requests>=1.3.3 requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.53
+---
+- Ensure pip installs selenium-requests >= 1.3.3 (github#296)
+
 1.52
 ---
 - No changes. Redeploy to pypi to update project URLs (github#292)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     name='mintapi',
     description='a screen-scraping API for Mint.com',
     long_description="https://github.com/mintapi/mintapi/",
-    version='1.52',
+    version='1.53',
     packages=['mintapi'],
     license='The MIT License',
     author='Michael Rooney',


### PR DESCRIPTION
This gets a PR for requirements.txt which I missed before, as well as the `install_requires` change in setup.py. Should cover most common scenarios!