### PR TITLE
update stablebot to consider PRs stale after 31 days

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,4 +1,5 @@
 # Configuration for probot-stale - https://github.com/probot/stale
+daysUntilStale: 31
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: ['awaiting-feedback']


### PR DESCRIPTION
After thinking about more, 60 days feels like a very long time to keep an issue open if we are waiting for feedback. 31 days + the 7 additional days after the comment feels quite generous for them or someone else to respond, and of course they can always respond later and we can open it back up. What do you think?