### PR TITLE
Change Account Continue Button to find by CSS Selector

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -425,9 +425,13 @@ def _sign_in(email, password, driver, mfa_method=None, mfa_token=None,
                     "//label/span[text()='{}']/../preceding-sibling::input".format(intuit_account))
                 account_input.click()
 
-            continue_btn = driver.find_element_by_css_selector('[data-testid="SelectAccountContinueButton"]')
-            driver.implicitly_wait(5)  # seconds
-            continue_btn.click()
+            continue_btn = driver.find_element_by_id("ius-sign-in-mfa-select-account-continue-btn")
+            if continue_btn is not None:
+                continue_btn.submit()
+            else:
+                continue_btn = driver.find_element_by_css_selector('[data-testid="SelectAccountContinueButton"]')
+                driver.implicitly_wait(5)  # seconds
+                continue_btn.click()
         except NoSuchElementException:
             pass  # not on account selection screen
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -424,7 +424,10 @@ def _sign_in(email, password, driver, mfa_method=None, mfa_token=None,
                 account_input = select_account.find_element_by_xpath(
                     "//label/span[text()='{}']/../preceding-sibling::input".format(intuit_account))
                 account_input.click()
-            driver.find_element_by_id("ius-sign-in-mfa-select-account-continue-btn").submit()
+
+            continue_btn = driver.find_element_by_css_selector('[data-testid="SelectAccountContinueButton"]')
+            driver.implicitly_wait(5)  # seconds
+            continue_btn.click()
         except NoSuchElementException:
             pass  # not on account selection screen
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -425,11 +425,15 @@ def _sign_in(email, password, driver, mfa_method=None, mfa_token=None,
                     "//label/span[text()='{}']/../preceding-sibling::input".format(intuit_account))
                 account_input.click()
 
-            continue_btn = driver.find_element_by_id("ius-sign-in-mfa-select-account-continue-btn")
-            if continue_btn is not None:
+            try:
+                continue_btn = driver.find_element_by_id(
+                    "ius-sign-in-mfa-select-account-continue-btn"
+                )
                 continue_btn.submit()
-            else:
-                continue_btn = driver.find_element_by_css_selector('[data-testid="SelectAccountContinueButton"]')
+            except NoSuchElementException:
+                continue_btn = driver.find_element_by_css_selector(
+                    '[data-testid="SelectAccountContinueButton"]'
+                )
                 driver.implicitly_wait(5)  # seconds
                 continue_btn.click()
         except NoSuchElementException:


### PR DESCRIPTION
At least on my account, finding by `id` doesn't work. On inspection, the Continue button has no `id` property, but it does have `data-testid="SelectAccountContinueButton"`. This patch updates the Account Selection method to work with both the current approach and on my account's approach.