### PR TITLE
feat: :sparkles: Expose sign_in as a public method to allow custom WebDrivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ If you're running mintapi in a server environment on an automatic schedule, cons
 
 If you need to download the chromedriver manually, be sure to get the version that matches your chrome version and make the chromedriver available to your python interpreter either by putting the chromedriver in your python working directory or inside your `PATH` as described in the [python selenium documentation](https://www.selenium.dev/selenium/docs/api/py/index.html#drivers).
 
+### General Automation Scenarios
+When running this inside of a cron job or other long-term automation scripts, it might be helpful to specify chrome and chromedriver executables so as not to conflict with other chrome versions you may have. Selenium by default just gets these from your `PATH` environment variable, so customizing your environment can force a deterministic behavior from mintapi. To use a different browser besides Chrome or Chromium, see the [python api](#from-python). Below are two examples.
+
+#### Unix Environment
+If I wanted to make sure that mintapi used the chromium executable in my /usr/bin directory when executing a cron job, I could write the following cron line:
+```cron
+0 7 * * FRI PATH=/usr/bin:$PATH mintapi --headless john@example.com my_password
+```
+where prepending the /usr/bin path to path will make those binaries found first. This will only affect the cron job and will not change the environment for any other process.
+
+#### Windows Environment
+You can do a similar thing in windows by executing the following in Powershell.
+```powershell
+$ENV:PATH = "C:\Program Files\Google\Chrome;$ENV:PATH"
+mintapi --headless john@example.com my_password
+```
+
 ### MFA Authentication Methods
 
 If mfa-method is email and your email host provides IMAP access, you can specify your IMAP login details.
@@ -132,7 +149,10 @@ make calls to retrieve account/budget information.  We recommend using the
   
   # you can also use mintapi's login in workflow with your own selenium webdriver
   # this will allow for more custom selenium driver setups
-  from seleniumrequests import Firefox  # needs to be based on selenium-requests
+  # one caveat is that it must be based on seleniumrequests currently
+  # seleniumrequests has most browsers already
+  # it also has mixins for any browsers it doesn't have so the sky is the limit!
+  from seleniumrequests import Firefox
   mint = mintapi.Mint()
   mint.driver = Firefox()
   mint.status_message, mint.token = mintapi.sign_in(
@@ -142,7 +162,9 @@ make calls to retrieve account/budget information.  We recommend using the
     imap_account=None, imap_password=None,
     imap_server=None, imap_folder="INBOX",
   )
-
+  # now you can do all the normal api calls
+  # ex:
+  mint.get_transactions()
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ make calls to retrieve account/budget information.  We recommend using the
 
   # Initiate an account refresh
   mint.initiate_account_refresh()
+  
+  # you can also use mintapi's login in workflow with your own selenium webdriver
+  # this will allow for more custom selenium driver setups
+  from seleniumrequests import Firefox  # needs to be based on selenium-requests
+  mint = mintapi.Mint()
+  mint.driver = Firefox()
+  mint.status_message, mint.token = mintapi.sign_in(
+    email, password, mint.driver, mfa_method=None, mfa_token=None,
+    mfa_input_callback=None, intuit_account=None, wait_for_sync=True,
+    wait_for_sync_timeout=5 * 60,
+    imap_account=None, imap_password=None,
+    imap_server=None, imap_folder="INBOX",
+  )
+
 ```
 
 ---

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -30,7 +30,6 @@ from selenium.webdriver import ChromeOptions
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.remote.webelement import WebElement
 from seleniumrequests import Chrome
 import xmltodict
 
@@ -578,7 +577,7 @@ def get_web_driver(
 
     status_message = None
     try:
-        sign_in(
+        status_message, _ = sign_in(
             email,
             password,
             driver,
@@ -593,38 +592,11 @@ def get_web_driver(
             imap_server,
             imap_folder,
         )
-
-        # Wait until the overview page has actually loaded, and if wait_for_sync==True, sync has completed.
-        if wait_for_sync:
-            try:
-                # Status message might not be present straight away. Seems to be due
-                # to dynamic content (client side rendering).
-                status_message = WebDriverWait(driver, 30).until(
-                    expected_conditions.visibility_of_element_located(
-                        (By.CSS_SELECTOR, ".SummaryView .message")
-                    )
-                )
-                WebDriverWait(driver, wait_for_sync_timeout).until(
-                    lambda x: "Account refresh complete"
-                    in status_message.get_attribute("innerHTML")
-                )
-            except (TimeoutException, StaleElementReferenceException):
-                logger.warning(
-                    "Mint sync apparently incomplete after timeout. "
-                    "Data retrieved may not be current."
-                )
-        else:
-            driver.find_element_by_id("transaction")
     except Exception as e:
         logger.exception(e)
         driver.quit()
         driver = None
 
-    if status_message is not None and isinstance(status_message, WebElement):
-        try:
-            status_message = status_message.text
-        except StaleElementReferenceException:
-            pass
     return driver, status_message
 
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -303,7 +303,6 @@ def _create_web_driver_at_mint_com(
             options=chrome_options,
             executable_path=get_stable_chrome_driver(chromedriver_download_path),
         )
-    driver.get("https://www.mint.com")
     return driver
 
 
@@ -326,6 +325,7 @@ def sign_in(
     Takes in a web driver and gets it through the Mint sign in process
     """
     driver.implicitly_wait(20)  # seconds
+    driver.get("https://www.mint.com")
     element = driver.find_element_by_link_text("Sign in")
     element.click()
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -129,9 +129,11 @@ class TestMock:
 
 
 class MintApiTests(unittest.TestCase):
-    @patch.object(mintapi.api, "get_web_driver")
-    def test_accounts(self, mock_driver):
-        mock_driver.return_value = (TestMock(), "test")
+    @patch.object(mintapi.api, "sign_in")
+    @patch.object(mintapi.api, "_create_web_driver_at_mint_com")
+    def test_accounts(self, mock_driver, mock_sign_in):
+        mock_driver.return_value = TestMock()
+        mock_sign_in.return_value = ("test", "token")
         accounts = mintapi.get_accounts("foo", "bar")
 
         self.assertFalse("lastUpdatedInDate" in accounts)
@@ -185,7 +187,7 @@ class MintApiTests(unittest.TestCase):
 
     @patch.object(mintapi.api, "_create_web_driver_at_mint_com")
     @patch.object(mintapi.api, "logger")
-    @patch.object(mintapi.api, "_sign_in")
+    @patch.object(mintapi.api, "sign_in")
     def test_when_sign_in_fails_then_logs_exception(
         self, mock_sign_in, mock_logger, *_
     ):
@@ -242,7 +244,7 @@ class GivenBrowserAtSignInPage(unittest.TestCase):
         self.driver.close()
 
     def test_sign_in(self):
-        mintapi.api._sign_in(test_args["username"], test_args["password"], self.driver)
+        mintapi.api.sign_in(test_args["username"], test_args["password"], self.driver)
         self.assertTrue(
             self.driver.current_url.startswith("https://mint.intuit.com/overview.event")
         )


### PR DESCRIPTION
* show deprecation warning on get_web_driver
* refactor login_and_get_token to cover get_web_driver
* document how to use sign_in with custom WebDriver

refs: #330

This is a proposal to replace #330 which will allow the user to specify custom WebDrivers so we don't have to explicitly expose every requested feature.