### PR TITLE
remove python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: mintapi build 
+name: mintapi build
 
 on: [push, pull_request]
 
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     author_email='mrooney.mintapi@rowk.com',
     url='https://github.com/mintapi/mintapi',
     install_requires=['configargparse', 'future', 'mock', 'oathtool', 'pandas>=1.0', 'requests', 'selenium', 'selenium-requests>=1.3.3', 'xmltodict'],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     entry_points=dict(
         console_scripts=[
             'mintapi = mintapi.api:main',


### PR DESCRIPTION
Just making this PR in advance since python 3.6 is EOL on Dec 23rd. I think it would also be fine to merge early since it seems only helpful to encourage upgrades, and I don't foresee any py3.6 issues coming up in the next few weeks, and it probably wouldn't make sense to fix anyway :) I'm also fine with waiting if that seems better.