### PR TITLE
Add command-line option to exclude credit inquiries from credit report data

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
 ```shell
     usage: mintapi [-h] [--session-path [SESSION_PATH]] [--accounts]
                    [--budgets | --budget_hist] [--net-worth] [--extended-accounts] [--transactions]
-                   [--extended-transactions] [--credit-score] [--credit-report]
+                   [--extended-transactions] [--credit-score] [--credit-report] [--exclude-inquiries]
                    [--start-date [START_DATE]] [--end-date [END_DATE]]
                    [--include-investment] [--skip-duplicates] [--show-pending]
                    [--filename FILENAME] [--keyring] [--headless] [--attention]
@@ -159,6 +159,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
       --config-file, -c     File used to store arguments
       --credit-score        Retrieve credit score
       --credit-report       Retrieve full credit report & history
+      --exclude-inquiries   Used in conjunction with --credit-report, ignores credit inquiry data.
       --net-worth           Retrieve net worth information
       --extended-accounts   Retrieve extended account information (slower, implies --accounts)
       --transactions, -t    Retrieve transactions

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1334,19 +1334,30 @@ class Mint(object):
         return self.driver.get(MINT_CREDIT_URL)
 
     def _get_credit_reports(self, limit, credit_header):
-        return self.get("{}/v1/creditreports?limit={}".format(MINT_CREDIT_URL, limit), headers=credit_header).json()
+        return self.get(
+            "{}/v1/creditreports?limit={}".format(MINT_CREDIT_URL, limit),
+            headers=credit_header,
+        ).json()
 
     def _get_credit_details(self, url, credit_header):
         return self.get(url.format(MINT_CREDIT_URL), headers=credit_header).json()
 
     def get_credit_inquiries(self, credit_header):
-        return self._get_credit_details("{}/v1/creditreports/0/inquiries", credit_header)
+        return self._get_credit_details(
+            "{}/v1/creditreports/0/inquiries", credit_header
+        )
 
     def get_credit_accounts(self, credit_header):
-        return self._get_credit_details("{}/v1/creditreports/0/tradelines", credit_header)
+        return self._get_credit_details(
+            "{}/v1/creditreports/0/tradelines", credit_header
+        )
 
     def get_credit_utilization(self, credit_header):
-        return self.__process_utilization(self._get_credit_details("{}/v1/creditreports/creditutilizationhistory", credit_header))
+        return self.__process_utilization(
+            self._get_credit_details(
+                "{}/v1/creditreports/creditutilizationhistory", credit_header
+            )
+        )
 
     def __process_utilization(self, data):
         # Function to clean up the credit utilization history data
@@ -1810,8 +1821,9 @@ def main():
     elif options.credit_score:
         data = mint.get_credit_score()
     elif options.credit_report:
-        data = mint.get_credit_report(details=True,
-                                      exclude_inquiries=options.exclude_inquiries)
+        data = mint.get_credit_report(
+            details=True, exclude_inquiries=options.exclude_inquiries
+        )
 
     # output the data
     if options.transactions or options.extended_transactions:

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1107,7 +1107,7 @@ class Mint(object):
         except (KeyError, IndexError):
             raise Exception('No Credit Score Found')
 
-    def get_credit_report(self, limit=2, details=True, exclude_inquiries):
+    def get_credit_report(self, limit=2, details=True, exclude_inquiries=False):
         # Get the browser API key, build auth header
         credit_header = self._get_api_key_header()
 
@@ -1130,21 +1130,18 @@ class Mint(object):
         # If we want details, request the detailed sub-reports
         if details:
             # Get full list of credit inquiries
-            response = self._get_credit_details('{}/v1/creditreports/0/inquiries', credit_header)
-            credit_report['inquiries'] = response.json()
+            credit_report['inquiries'] = self._get_credit_details('{}/v1/creditreports/0/inquiries', credit_header)
 
             # Get full list of credit accounts
-            response = self._get_credit_details('{}/v1/creditreports/0/tradelines', credit_header)
-            credit_report['accounts'] = response.json()
+            credit_report['accounts'] = self._get_credit_details('{}/v1/creditreports/0/tradelines', credit_header)
 
             # Get credit utilization history (~3 months, by account)
-            response = self._get_credit_details('{}/v1/creditreports/creditutilizationhistory', credit_header)
-            credit_report['utilization'] = self.process_utilization(response.json())
+            credit_report['utilization'] = self.process_utilization(self._get_credit_details('{}/v1/creditreports/creditutilizationhistory', credit_header))
 
         return credit_report
 
     def _get_credit_details(self, url, credit_header):
-        return self.get(url.format(MINT_CREDIT_URL), headers=credit_header)
+        return self.get(url.format(MINT_CREDIT_URL), headers=credit_header).json()
 
     def process_utilization(self, data):
         # Function to clean up the credit utilization history data

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1114,14 +1114,14 @@ class Mint(object):
 
     def get_credit_score(self):
         # Request a single credit report, and extract the score
-        report = self.get_credit_report(limit=1, details=False)
+        report = self.get_credit_report(limit=1, details=False, exclude_inquiries=False)
         try:
             vendor = report['reports']['vendorReports'][0]
             return vendor['creditReportList'][0]['creditScore']
         except (KeyError, IndexError):
             raise Exception('No Credit Score Found')
 
-    def get_credit_report(self, limit=2, details=True):
+    def get_credit_report(self, limit=2, details=True, exclude_inquiries):
         # Get the browser API key, build auth header
         credit_header = self._get_api_key_header()
 
@@ -1197,6 +1197,7 @@ def parse_arguments(args):
         (('--credit-report', ), {'action': 'store_true', 'dest': 'credit_report', 'default': False, 'help': 'Retrieve full credit report'}),
         (('--credit-score', ), {'action': 'store_true', 'dest': 'credit_score', 'default': False, 'help': 'Retrieve current credit score'}),
         (('--end-date', ), {'nargs': '?', 'default': None, 'help': 'Latest date for transactions to be retrieved from. Used with --extended-transactions. Format: mm/dd/yy'}),
+        (('--exclude-inquiries', ), {'action': 'store_true', 'help': 'When accessing credit report details, exclude data related to credit inquiries.  Used with --credit-report.'}),
         (('--extended-accounts', ), {'action': 'store_true', 'dest': 'accounts_ext', 'default': False, 'help': 'Retrieve extended account information (slower, implies --accounts)'}),
         (('--extended-transactions', ), {'action': 'store_true', 'default': False, 'help': 'Retrieve transactions with extra information and arguments'}),
         (('--filename', '-f'), {'help': 'write results to file. can be {csv,json} format. default is to write to stdout.'}),
@@ -1405,7 +1406,8 @@ def main():
     elif options.credit_score:
         data = mint.get_credit_score()
     elif options.credit_report:
-        data = mint.get_credit_report(details=True)
+        data = mint.get_credit_report(details=True,
+                                      exclude_inquiries=options.exclude_inquiries)
 
     # output the data
     if options.transactions or options.extended_transactions:

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1128,7 +1128,7 @@ class Mint(object):
                 credit_report['inquiries'] = self.get_credit_inquiries(credit_header)
 
             # Get full list of credit accounts
-            credit_report['accounts'] =  self.get_credit_accounts(credit_header)
+            credit_report['accounts'] = self.get_credit_accounts(credit_header)
 
             # Get credit utilization history (~3 months, by account)
             credit_report['utilization'] = self.get_credit_utilization(credit_header)

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1154,17 +1154,17 @@ class Mint(object):
         return self._get_credit_details('{}/v1/creditreports/0/tradelines', credit_header)
 
     def get_credit_utilization(self, credit_header):
-        return self.process_utilization(self._get_credit_details('{}/v1/creditreports/creditutilizationhistory', credit_header))
+        return self.__process_utilization(self._get_credit_details('{}/v1/creditreports/creditutilizationhistory', credit_header))
 
-    def process_utilization(self, data):
+    def __process_utilization(self, data):
         # Function to clean up the credit utilization history data
         utilization = []
-        utilization.extend(self.flatten_utilization(data['cumulative']))
+        utilization.extend(self.__flatten_utilization(data['cumulative']))
         for trade in data['tradelines']:
-            utilization.extend(self.flatten_utilization(trade))
+            utilization.extend(self.__flatten_utilization(trade))
         return utilization
 
-    def flatten_utilization(self, data):
+    def __flatten_utilization(self, data):
         # The utilization history data has a nested format, grouped by year
         # and then by month. Let's flatten that into a list of dates.
         utilization = []

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -181,6 +181,29 @@ class MintApiTests(unittest.TestCase):
         self.assertTrue('parentCategoryName' in results_with_parents)
         self.assertTrue('parentCategoryId' in results_with_parents)
 
+
+    @patch.object(mintapi.Mint, '_get_api_key_header')
+    @patch.object(mintapi.Mint, '_load_mint_credit_url')
+    @patch.object(mintapi.api, 'get_web_driver')
+    @patch.object(mintapi.Mint, '_get_credit_reports')
+    @patch.object(mintapi.Mint, 'get_credit_inquiries')
+    @patch.object(mintapi.Mint, 'get_credit_accounts')
+    @patch.object(mintapi.Mint, 'get_credit_utilization')
+
+    def test_exclude_inquiries(self, mock_get_api_key_header, mock_load_mint_credit_url, mock_driver, mock_get_credit_reports, mock_get_credit_inquiries, mock_get_credit_accounts, mock_get_credit_utilization):
+        mint = mintapi.Mint()
+        test_value = "test"
+        credit_test = {test_value}
+        mock_get_api_key_header.return_value = test_value
+        mock_load_mint_credit_url.return_value = test_value
+        mock_driver.return_value = (TestMock(), "test")
+        mock_get_credit_reports.return_value = credit_test
+        mock_get_credit_inquiries.return_value = credit_test
+        mock_get_credit_accounts.return_value = credit_test
+        mock_get_credit_utilization.return_value = credit_test
+        credit_report = mint.get_credit_report(limit=2, details=True, exclude_inquiries=True)
+        self.assertFalse('inquiries' in credit_report)
+
     @patch.object(mintapi.api, '_create_web_driver_at_mint_com')
     @patch.object(mintapi.api, 'logger')
     @patch.object(mintapi.api, '_sign_in')

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -202,12 +202,12 @@ class MintApiTests(unittest.TestCase):
     @patch.object(mintapi.Mint, "get_credit_utilization")
     def test_exclude_inquiries(
         self,
-        mock_get_api_key_header,
-        mock_load_mint_credit_url,
-        mock_driver,
-        mock_get_credit_reports,
-        mock_get_credit_accounts,
         mock_get_credit_utilization,
+        mock_get_credit_accounts,
+        mock_get_credit_reports,
+        mock_driver,
+        mock_load_mint_credit_url,
+        mock_get_api_key_header,
     ):
         mint = mintapi.Mint()
         test_value = "test"

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -189,7 +189,6 @@ class MintApiTests(unittest.TestCase):
     @patch.object(mintapi.Mint, 'get_credit_inquiries')
     @patch.object(mintapi.Mint, 'get_credit_accounts')
     @patch.object(mintapi.Mint, 'get_credit_utilization')
-
     def test_exclude_inquiries(self, mock_get_api_key_header, mock_load_mint_credit_url, mock_driver, mock_get_credit_reports, mock_get_credit_inquiries, mock_get_credit_accounts, mock_get_credit_utilization):
         mint = mintapi.Mint()
         test_value = "test"

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -186,10 +186,9 @@ class MintApiTests(unittest.TestCase):
     @patch.object(mintapi.Mint, '_load_mint_credit_url')
     @patch.object(mintapi.api, 'get_web_driver')
     @patch.object(mintapi.Mint, '_get_credit_reports')
-    @patch.object(mintapi.Mint, 'get_credit_inquiries')
     @patch.object(mintapi.Mint, 'get_credit_accounts')
     @patch.object(mintapi.Mint, 'get_credit_utilization')
-    def test_exclude_inquiries(self, mock_get_api_key_header, mock_load_mint_credit_url, mock_driver, mock_get_credit_reports, mock_get_credit_inquiries, mock_get_credit_accounts, mock_get_credit_utilization):
+    def test_exclude_inquiries(self, mock_get_api_key_header, mock_load_mint_credit_url, mock_driver, mock_get_credit_reports, mock_get_credit_accounts, mock_get_credit_utilization):
         mint = mintapi.Mint()
         test_value = "test"
         credit_test = {test_value}
@@ -197,7 +196,6 @@ class MintApiTests(unittest.TestCase):
         mock_load_mint_credit_url.return_value = test_value
         mock_driver.return_value = (TestMock(), "test")
         mock_get_credit_reports.return_value = credit_test
-        mock_get_credit_inquiries.return_value = credit_test
         mock_get_credit_accounts.return_value = credit_test
         mock_get_credit_utilization.return_value = credit_test
         credit_report = mint.get_credit_report(limit=2, details=True, exclude_inquiries=True)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -12,7 +12,7 @@ import pandas as pd
 import requests
 import tempfile
 
-from unittest.mock import patch
+from unittest.mock import patch, DEFAULT
 
 # add mintapi to path so it can be accessed even if not running from mintapi folder
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -194,30 +194,16 @@ class MintApiTests(unittest.TestCase):
         mintapi.Mint("test", "test")
         mock_logger.exception.assert_called_with(test_exception)
 
-    @patch.object(mintapi.Mint, "_get_api_key_header")
-    @patch.object(mintapi.Mint, "_load_mint_credit_url")
-    @patch.object(mintapi.api, "get_web_driver")
-    @patch.object(mintapi.Mint, "_get_credit_reports")
-    @patch.object(mintapi.Mint, "get_credit_accounts")
-    @patch.object(mintapi.Mint, "get_credit_utilization")
-    def test_exclude_inquiries(
-        self,
-        mock_get_credit_utilization,
-        mock_get_credit_accounts,
-        mock_get_credit_reports,
-        mock_driver,
-        mock_load_mint_credit_url,
-        mock_get_api_key_header,
-    ):
+    @patch.multiple(
+        mintapi.Mint,
+        _get_api_key_header=DEFAULT,
+        _load_mint_credit_url=DEFAULT,
+        _get_credit_reports=DEFAULT,
+        get_credit_accounts=DEFAULT,
+        get_credit_utilization=DEFAULT,
+    )
+    def test_exclude_inquiries(self, **_):
         mint = mintapi.Mint()
-        test_value = "test"
-        credit_test = {test_value}
-        mock_get_api_key_header.return_value = test_value
-        mock_load_mint_credit_url.return_value = test_value
-        mock_driver.return_value = (TestMock(), "test")
-        mock_get_credit_reports.return_value = credit_test
-        mock_get_credit_accounts.return_value = credit_test
-        mock_get_credit_utilization.return_value = credit_test
         credit_report = mint.get_credit_report(
             limit=2, details=True, exclude_inquiries=True
         )

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -200,7 +200,15 @@ class MintApiTests(unittest.TestCase):
     @patch.object(mintapi.Mint, "_get_credit_reports")
     @patch.object(mintapi.Mint, "get_credit_accounts")
     @patch.object(mintapi.Mint, "get_credit_utilization")
-    def test_exclude_inquiries(self, mock_get_api_key_header, mock_load_mint_credit_url, mock_driver, mock_get_credit_reports, mock_get_credit_accounts, mock_get_credit_utilization):
+    def test_exclude_inquiries(
+        self,
+        mock_get_api_key_header,
+        mock_load_mint_credit_url,
+        mock_driver,
+        mock_get_credit_reports,
+        mock_get_credit_accounts,
+        mock_get_credit_utilization,
+    ):
         mint = mintapi.Mint()
         test_value = "test"
         credit_test = {test_value}
@@ -210,8 +218,10 @@ class MintApiTests(unittest.TestCase):
         mock_get_credit_reports.return_value = credit_test
         mock_get_credit_accounts.return_value = credit_test
         mock_get_credit_utilization.return_value = credit_test
-        credit_report = mint.get_credit_report(limit=2, details=True, exclude_inquiries=True)
-        self.assertFalse('inquiries' in credit_report)
+        credit_report = mint.get_credit_report(
+            limit=2, details=True, exclude_inquiries=True
+        )
+        self.assertFalse("inquiries" in credit_report)
 
     def test_config_file(self):
         # verify parsing from config file


### PR DESCRIPTION
The changes made to `api.py` ended up being more involved only to provide a better foundation for the tests needed.  If there are any suggestions to better accommodate the test scenario, I'm all ears, but the test is working correctly and the results of the command-line option are as expected as well.

This is to resolve #326 .