### PR TITLE
release version 1.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.58
+---
+- expose sign_in as a public method to allow custom WebDrivers (#336)
+- add command-line option to exclude credit inquiries from credit report data (#340)
+- add command-line option to exclude credit accounts from credit report (#351)
+- fix performance degradation on extended transactions (#348)
+- remove support for Python 2.x
+
 1.57
 ---
 - add date range support to --transactions (github#321)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     name="mintapi",
     description="a screen-scraping API for Mint.com",
     long_description="https://github.com/mintapi/mintapi/",
-    version="1.57",
+    version="1.58",
     packages=["mintapi"],
     license="The MIT License",
     author="Michael Rooney",


### PR DESCRIPTION
Party time, lots of goodies here! I believe these are all appropriate for a 1.x version bump.

1.58
---
- expose sign_in as a public method to allow custom WebDrivers (#336)
- add command-line option to exclude credit inquiries from credit report data (#340)
- add command-line option to exclude credit accounts from credit report (#351)
- fix performance degradation on extended transactions (#348)
- remove support for Python 2.x