### PR TITLE
✨ Use keyring for IMAP password

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ mintapi --headless john@example.com my_password
 
 ### MFA Authentication Methods
 
-If mfa-method is email and your email host provides IMAP access, you can specify your IMAP login details.
-This will automate the retrieval of the MFA code from your email and entering it into Mint.
+If `mfa-method` is email and your email host provides IMAP access, you can specify your IMAP login details.
+This will automate the retrieval of the MFA code from your email and entering it into Mint.  If you use IMAP in conjunction with `keyring`, then you can store your IMAP password (`imap-password`) in keyring.  To do so, simply omit `imap-password` and you will initially be prompted for the password associated with your IMAP account.  Then, on subsequent uses of your IMAP account, you will not have to specify your password.
 
-If mfa-method is soft-token then you must also pass your mfa-token. The mfa-token can be obtained by going to [your mint.com settings](https://mint.intuit.com/settings.event?filter=all) and clicking on 'Intuit Account'. From there go to *Sign In & Security* -> *Two-step verification*. From there, enable the top option however you wish (either text or email is fine). After that, start the process to enable the *Authenticator app* option and when you get the part where you see the QR code, **copy the manual setup code** that appears next to it. Careful where you store this as it allows anyone to generate TOTP codes. This is the token that you will pass to `mfa-token` in either the python api or from the command line.
+If `mfa-method` is soft-token then you must also pass your `mfa-token`. The `mfa-token` can be obtained by going to [your mint.com settings](https://mint.intuit.com/settings.event?filter=all) and clicking on 'Intuit Account'. From there go to *Sign In & Security* -> *Two-step verification*. From there, enable the top option however you wish (either text or email is fine). After that, start the process to enable the *Authenticator app* option and when you get the part where you see the QR code, **copy the manual setup code** that appears next to it. Careful where you store this as it allows anyone to generate TOTP codes. This is the token that you will pass to `mfa-token` in either the python api or from the command line.
 
 ### from Python
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1784,7 +1784,7 @@ def main():
 
     if mfa_method == "email" and imap_account:
         imap_password = handle_password(
-            "imap",
+            "mintapi_imap",
             "IMAP password: ",
             imap_account,
             imap_password,


### PR DESCRIPTION
To enhance the security potential and increase consistency of how we handle password, I have created the following:
* A common method to handle password logic based on a given username.
* Apply the new method to Mint Username and Password
* Apply the new method to IMAP Username and Password in `mfa_method="email"` and if `imap_account`.