### PR TITLE
Move Black Linter to separate GitHub step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
-name: mintapi build 
+name: mintapi build
 
 on: [push, pull_request]
 
 jobs:
-  build:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: lint
+        uses: psf/black@stable
 
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -30,8 +36,6 @@ jobs:
         run:
           python -m pip install --upgrade pip
           pip install -r requirements.txt pytest
-      - name: lint
-        uses: psf/black@stable
       - name: Tests
         run:
           pytest


### PR DESCRIPTION
For contributors, it is helpful to evaluate the GitHub checks in a more modular manner.  In particular, it is helpful to have a separate step for running the Black linter from the actual tests associated with each version of Python.