### PR TITLE
Adapt to new css selector for submitting OTP

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -497,7 +497,7 @@ def sign_in(
                 account_input.click()
 
             mfa_code_submit = driver.find_element_by_css_selector(
-               '#ius-sign-in-mfa-select-account-continue-btn, [data-testid="SelectAccountContinueButton"]'
+                '#ius-sign-in-mfa-select-account-continue-btn, [data-testid="SelectAccountContinueButton"]'
             )
             continue_btn.click()
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -474,7 +474,9 @@ def sign_in(
                         )
                     mfa_code_input.send_keys(mfa_code)
 
-                    mfa_code_submit = driver.find_element_by_css_selector('#ius-mfa-otp-submit-btn, [data-testid="VerifyOtpSubmitButton"]')
+                    mfa_code_submit = driver.find_element_by_css_selector(
+                        '#ius-mfa-otp-submit-btn, [data-testid="VerifyOtpSubmitButton"]'
+                    )
 
                     mfa_code_submit.click()
                 except (NoSuchElementException, ElementNotInteractableException):

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -474,14 +474,7 @@ def sign_in(
                         )
                     mfa_code_input.send_keys(mfa_code)
 
-                    try:
-                        mfa_code_submit = driver.find_element_by_id(
-                            "ius-mfa-otp-submit-btn"
-                        )
-                    except NoSuchElementException:
-                        mfa_code_submit = driver.find_element_by_css_selector(
-                            '[data-testid="VerifyOtpSubmitButton"]'
-                        )
+                    mfa_code_submit = driver.find_element_by_css_selector('#ius-mfa-otp-submit-btn, [data-testid="VerifyOtpSubmitButton"]')
 
                     mfa_code_submit.click()
                 except (NoSuchElementException, ElementNotInteractableException):

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -496,16 +496,11 @@ def sign_in(
                 )
                 account_input.click()
 
-            try:
-                continue_btn = driver.find_element_by_id(
-                    "ius-sign-in-mfa-select-account-continue-btn"
-                )
-                continue_btn.submit()
-            except NoSuchElementException:
-                continue_btn = driver.find_element_by_css_selector(
-                    '[data-testid="SelectAccountContinueButton"]'
-                )
-                continue_btn.click()
+            mfa_code_submit = driver.find_element_by_css_selector(
+               '#ius-sign-in-mfa-select-account-continue-btn, [data-testid="SelectAccountContinueButton"]'
+            )
+            continue_btn.click()
+
         except NoSuchElementException:
             pass  # not on account selection screen
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -474,9 +474,15 @@ def sign_in(
                         )
                     mfa_code_input.send_keys(mfa_code)
 
-                    mfa_code_submit = driver.find_element_by_id(
-                        "ius-mfa-otp-submit-btn"
-                    )
+                    try:
+                        mfa_code_submit = driver.find_element_by_id(
+                            "ius-mfa-otp-submit-btn"
+                        )
+                    except NoSuchElementException:
+                        mfa_code_submit = driver.find_element_by_css_selector(
+                            '[data-testid="VerifyOtpSubmitButton"]'
+                        )
+
                     mfa_code_submit.click()
                 except (NoSuchElementException, ElementNotInteractableException):
                     pass  # we're not on mfa input screen


### PR DESCRIPTION
Mint has a new css selector for submitting a one time password.  This pull request works for either the old or new ways to submit the OTP.