### PR TITLE
release/deploy improvements for pypi

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -ex
+rm -rf dist && python setup.py sdist
+python -m twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(readme, "r") as fh:
 setuptools.setup(
     name="mintapi",
     description="a screen-scraping API for Mint.com",
-    long_description=long_description,
+    long_description="https://github.com/mintapi/mintapi/",
     version="1.59",
     packages=["mintapi"],
     license="The MIT License",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ with open(readme, "r") as fh:
 setuptools.setup(
     name="mintapi",
     description="a screen-scraping API for Mint.com",
-    long_description="https://github.com/mintapi/mintapi/",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     version="1.59",
     packages=["mintapi"],
     license="The MIT License",


### PR DESCRIPTION
This adds a deploy script, which is mostly just convenience for me to perform new uploads to pypi.

It also reverts the long description change since that was running into:

```
The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.
```