### PR TITLE
🧹 Validate file extension before data is retrieved

### DIFF
--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -318,6 +318,54 @@ def handle_password(type, prompt, email, password, use_keyring=False):
     return password
 
 
+def validate_file_extensions(options):
+    if any(
+        [
+            options.transactions,
+            options.extended_transactions,
+        ]
+    ):
+        if not any(
+            [
+                options.filename is None,
+                options.filename.endswith(".csv"),
+                options.filename.endswith(".json"),
+            ]
+        ):
+            raise ValueError(
+                "File extension must be either .csv or .json for transaction data"
+            )
+    else:
+        if not any([options.filename is None, options.filename.endswith(".json")]):
+            raise ValueError("File extension must be .json for non-transaction data")
+
+
+def output_data(options, data, attention_msg=None):
+    # output the data
+    if options.transactions or options.extended_transactions:
+        if options.filename is None:
+            print(data.to_json(orient="records"))
+        elif options.filename.endswith(".csv"):
+            data.to_csv(options.filename, index=False)
+        elif options.filename.endswith(".json"):
+            data.to_json(options.filename, orient="records")
+    else:
+        if options.filename is None:
+            print(json.dumps(data, indent=2))
+        elif options.filename.endswith(".json"):
+            with open(options.filename, "w+") as f:
+                json.dump(data, f, indent=2)
+
+    if options.attention:
+        if attention_msg is None or attention_msg == "":
+            attention_msg = "no messages"
+        if options.filename is None:
+            print(attention_msg)
+        else:
+            with open(options.filename, "w+") as f:
+                f.write(attention_msg)
+
+
 def main():
     options = parse_arguments(sys.argv[1:])
 
@@ -327,6 +375,8 @@ def main():
     imap_account = options.imap_account
     imap_password = options.imap_password
     mfa_method = options.mfa_method
+
+    validate_file_extensions(options)
 
     if not email:
         # If the user did not provide an e-mail, prompt for it
@@ -457,31 +507,6 @@ def main():
             exclude_utilization=options.exclude_utilization,
         )
 
-    # output the data
-    if options.transactions or options.extended_transactions:
-        if options.filename is None:
-            print(data.to_json(orient="records"))
-        elif options.filename.endswith(".csv"):
-            data.to_csv(options.filename, index=False)
-        elif options.filename.endswith(".json"):
-            data.to_json(options.filename, orient="records")
-        else:
-            raise ValueError("file extension must be either .csv or .json")
-    else:
-        if options.filename is None:
-            print(json.dumps(data, indent=2))
-        elif options.filename.endswith(".json"):
-            with open(options.filename, "w+") as f:
-                json.dump(data, f, indent=2)
-        else:
-            raise ValueError("file type must be json for non-transaction data")
-
     if options.attention:
         attention_msg = mint.get_attention()
-        if attention_msg is None or attention_msg == "":
-            attention_msg = "no messages"
-        if options.filename is None:
-            print(attention_msg)
-        else:
-            with open(options.filename, "w+") as f:
-                f.write(attention_msg)
+    output_data(options, data, attention_msg)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -247,10 +247,8 @@ class MintApiTests(unittest.TestCase):
 
     def test_config_file(self):
         # verify parsing from config file
-        config_file = tempfile.NamedTemporaryFile(mode="wt")
-        config_file.write("extended-transactions")
-        config_file.flush()
-        arguments = mintapi.cli.parse_arguments(["-c", config_file.name])
+        config_file = write_extended_transactions_file()
+        arguments = parse_arguments_file(config_file)
         self.assertEqual(arguments.extended_transactions, True)
         config_file.close()
 
@@ -266,6 +264,41 @@ class MintApiTests(unittest.TestCase):
         investment_data = mintapi.Mint().get_investment_data()[0]
         self.assertFalse("metaData" in investment_data)
         self.assertTrue("lastUpdatedDate" in investment_data)
+
+    def test_validate_file_extensions(self):
+        config_file = write_extended_transactions_file()
+        config_file.write("filename=/tmp/transactions.txt")
+        arguments = parse_arguments_file(config_file)
+        self.assertRaises(ValueError, mintapi.cli.validate_file_extensions, arguments)
+        config_file = write_extended_transactions_file()
+        config_file.write("filename=/tmp/transactions.csv")
+        arguments = parse_arguments_file(config_file)
+        self.assertEqual(mintapi.cli.validate_file_extensions(arguments), None)
+        config_file = write_accounts_file()
+        config_file.write("filename=/tmp/accounts.csv")
+        arguments = parse_arguments_file(config_file)
+        self.assertRaises(ValueError, mintapi.cli.validate_file_extensions, arguments)
+        config_file = write_accounts_file()
+        config_file.write("filename=/tmp/accounts.json")
+        arguments = parse_arguments_file(config_file)
+        self.assertEqual(mintapi.cli.validate_file_extensions(arguments), None)
+
+
+def write_extended_transactions_file():
+    config_file = tempfile.NamedTemporaryFile(mode="wt")
+    config_file.write("extended-transactions\n")
+    return config_file
+
+
+def write_accounts_file():
+    config_file = tempfile.NamedTemporaryFile(mode="wt")
+    config_file.write("accounts\n")
+    return config_file
+
+
+def parse_arguments_file(config_file):
+    config_file.flush()
+    return mintapi.cli.parse_arguments(["-c", config_file.name])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR includes the following:
* Create a method to perform output filename extensions _before_ we retrieve data.
* Create a method to output the data
* Add test cases for validating that the new filename extension validator works.
* Addresses one of the concerns raised in #88 