### PR TITLE
update pandas to latest for python 3.10 wheel and faster builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ future==0.18.2
 keyring==23.2.1
 mock==4.0.2
 oathtool==2.3.0
-pandas==1.1.4
+pandas==1.3.5
 selenium-requests==1.3.3
 xmltodict==0.12.0


### PR DESCRIPTION
Addresses #373. I had to remove python 3.6 (which is EOL in 8 days) as pypi doesn't have a build for a version of pandas that also has a wheel for 3.10. If there's a way to handle both that I missed, let me know!