### PR TITLE
Include investment transactions for csv export

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -835,7 +835,7 @@ class Mint(object):
         return utilization
     
     def __include_investments_with_transactions(id, include_investment):
-        return (id > 0 or include_investment)
+        return id > 0 or include_investment
 
 
 def get_accounts(email, password, get_detail=False):

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -835,7 +835,7 @@ class Mint(object):
                     }
                 )
         return utilization
- 
+
     def __include_investments_with_transactions(id, include_investment):
         return id > 0 or include_investment
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -833,9 +833,10 @@ class Mint(object):
                     }
                 )
         return utilization
+
     
-    def __include_investments_with_transactions(id, include_investment):
-        return id > 0 or include_investment
+def __include_investments_with_transactions(id, include_investment):
+    return id > 0 or include_investment
 
 
 def get_accounts(email, password, get_detail=False):

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -426,7 +426,7 @@ class Mint(object):
             # Specifying accountId=0 causes Mint to return investment
             # transactions as well.  Otherwise they are skipped by
             # default.
-            if id > 0 or include_investment:
+            if __include_investments_with_transactions(id, include_investment):
                 params["accountId"] = id
             if include_investment:
                 params["task"] = "transactions"
@@ -514,7 +514,7 @@ class Mint(object):
         # default.
 
         params = {
-            "accountId": acct if (acct > 0 or include_investment) else None,
+            "accountId": acct if __include_investments_with_transactions(acct, include_investment) else None,
             "startDate": convert_date_to_string(convert_mmddyy_to_datetime(start_date)),
             "endDate": convert_date_to_string(convert_mmddyy_to_datetime(end_date)),
         }
@@ -833,6 +833,9 @@ class Mint(object):
                     }
                 )
         return utilization
+    
+    def __include_investments_with_transactions(id, include_investment):
+        return (id > 0 or include_investment):
 
 
 def get_accounts(email, password, get_detail=False):

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -835,7 +835,7 @@ class Mint(object):
         return utilization
     
     def __include_investments_with_transactions(id, include_investment):
-        return id > 0 or include_investment:
+        return (id > 0 or include_investment)
 
 
 def get_accounts(email, password, get_detail=False):

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -514,6 +514,9 @@ class Mint(object):
         # default.
 
         params = {
+            "accountId": acct
+            if __include_investments_with_transactions(acct, include_investment)
+            else None,
             "accountId": acct if __include_investments_with_transactions(acct, include_investment) else None,
             "startDate": convert_date_to_string(convert_mmddyy_to_datetime(start_date)),
             "endDate": convert_date_to_string(convert_mmddyy_to_datetime(end_date)),
@@ -833,10 +836,9 @@ class Mint(object):
                     }
                 )
         return utilization
-
     
-def __include_investments_with_transactions(id, include_investment):
-    return id > 0 or include_investment
+    def __include_investments_with_transactions(id, include_investment):
+        return id > 0 or include_investment
 
 
 def get_accounts(email, password, get_detail=False):

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -514,7 +514,7 @@ class Mint(object):
         # default.
 
         params = {
-            "accountId": acct if acct > 0 else None,
+            "accountId": acct if (acct > 0 or include_investment) else None,
             "startDate": convert_date_to_string(convert_mmddyy_to_datetime(start_date)),
             "endDate": convert_date_to_string(convert_mmddyy_to_datetime(end_date)),
         }

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -835,7 +835,7 @@ class Mint(object):
         return utilization
     
     def __include_investments_with_transactions(id, include_investment):
-        return (id > 0 or include_investment):
+        return id > 0 or include_investment:
 
 
 def get_accounts(email, password, get_detail=False):

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -517,7 +517,6 @@ class Mint(object):
             "accountId": acct
             if __include_investments_with_transactions(acct, include_investment)
             else None,
-            "accountId": acct if __include_investments_with_transactions(acct, include_investment) else None,
             "startDate": convert_date_to_string(convert_mmddyy_to_datetime(start_date)),
             "endDate": convert_date_to_string(convert_mmddyy_to_datetime(end_date)),
         }
@@ -836,6 +835,7 @@ class Mint(object):
                     }
                 )
         return utilization
+ 
     
     def __include_investments_with_transactions(id, include_investment):
         return id > 0 or include_investment

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -836,7 +836,6 @@ class Mint(object):
                 )
         return utilization
  
-    
     def __include_investments_with_transactions(id, include_investment):
         return id > 0 or include_investment
 


### PR DESCRIPTION
Fixes #383, mimicking behavior for `get_transactions_json`: https://github.com/mintapi/mintapi/blob/1ea57748ff891d55ba1e7275a60d1214a67622c5/mintapi/api.py#L429