### PR TITLE
Fixing cli checking file extensions

### DIFF
--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -334,18 +334,16 @@ def validate_file_extensions(options):
             options.extended_transactions,
         ]
     ):
-        if not any(
-            [
-                options.filename is None,
-                options.filename.endswith(".csv"),
-                options.filename.endswith(".json"),
-            ]
+        if not (
+            options.filename is None
+            or options.filename.endswith(".csv")
+            or options.filename.endswith(".json")
         ):
             raise ValueError(
                 "File extension must be either .csv or .json for transaction data"
             )
     else:
-        if not any([options.filename is None, options.filename.endswith(".json")]):
+        if not (options.filename is None or options.filename.endswith(".json")):
             raise ValueError("File extension must be .json for non-transaction data")
 
 


### PR DESCRIPTION
Proposed fix for #385 by just removing the `any` and using `or` for the booleans instead.