### PR TITLE
ci: :construction_worker: Add docker workflow and image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM selenium/standalone-chrome
+
+# add mintapi to path
+ENV PATH=$HOME/.local/bin:$PATH
+
+RUN echo "**** install packages ****" && \
+    sudo apt-get update && \
+    sudo apt-get install -y python3-pip && \
+    pip3 install mintapi && \
+    echo "**** cleanup ****" && \
+    sudo apt-get clean && \
+    sudo rm -rf \
+	/tmp/* \
+	/var/lib/apt/lists/* \
+	/var/tmp/*
+
+# make mintapi help menu default command
+CMD mintapi -h

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,35 @@
+name: Create and publish Docker image
+
+on:
+  push:
+    branches:
+    - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          file: .docker/Dockerfile

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ If I wanted to make sure that mintapi used the chromium executable in my /usr/bi
 ```
 where prepending the /usr/bin path to path will make those binaries found first. This will only affect the cron job and will not change the environment for any other process.
 
+#### Docker Image
+You can also use the docker image to help manage your environment so you don't have to worry about chrome or chromedriver versions. There are a few caveats:
+1. Headless mode is recommended. GUI works but introduces the need to configure an X11 server which varies with setup. Google is your friend.
+2. Almost always use the flag `--use-chromedriver-on-path` as the chrome and chromedriver built into the docker image already match and getting the latest will break the image.
+3. If you want to persist credentials or your chrome session, you'll need to do some volume mounting.
+
+To use the image:
+```
+docker run --rm --shm-size=2g ghcr.io/mintapi/mintapi mintapi john@example.com my_password --headless --use-chromedriver-on-path
+```
+
 #### Windows Environment
 You can do a similar thing in windows by executing the following in Powershell.
 ```powershell

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         "oathtool",
         "pandas>=1.0",
         "requests",
-        "selenium",
+        "selenium<4.0.0",
         "selenium-requests>=1.3.3",
         "xmltodict",
         "keyring",


### PR DESCRIPTION
* adds Dockerfile that includes mintapi and chrome
* adds docker instructions to README.md
* removes selenium from setup.py to fix dependency resolver
* adds docker build workflow that build on push to main

Some notes/thoughts:
1. Since we don't tag or otherwise mark releases in GitHub, there's no way to know when to trigger the docker workflow to publish a new image. I just set it up to run every time there's a push to main and there will be just nothing to push if nothing new was published to PyPI. We might want to consider tagging releases. This will also make debugging easier in the future.
2. I had to modify the install_requires in setup.py as pip's buggy dependency resolver kept ignoring selenium_requests when it sees ours dependency on selenium. I think this has to do with the docker image having an older pip version with a worse dependency resolver than the one on my laptop. My modification doesn't actually change what should be installed, it just helps pip see that selenium can't be over version 4 (which is the requirement of selenium_requests that pip ignores on older versions).