### PR TITLE
🔨 Dynamic Multifactor Authentication Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.0 (Pending)
 ---
 
+- Dynamic Multifactor Authentication Flow (#392)
 - Add Data Format Option to CLI: `--format` (#432)
 - Update Accounts Endpoint to meet new Mint requirements (#430) 
 - Update Transactions Endpoint to meet new Mint requirements (#429) 
@@ -12,8 +13,10 @@
 - Update the overview page url (#414) 
 
 BREAKING CHANGES:
+- :warning: `mfa_method` is only required if your login flow presents you with the option to select which Multifactor Authentication Method you wish to use, typically as a result of your account configured to accept different methods.  #392 provided a way to automatically detect the type of MFA requested by Mint, based on the prompts on the screen.  Because of this, Mintapi now supports the use case where multiple MFA prompts appear.
 - Because of the new Mint UI and the switchover to different API Endpoints, the data structure associated with each function may be different.  Please verify that the data you are expecting against the new output of each endpoint.
 - To help support the new CLI option for data format (`--format`), we have eliminated the need to specify a file extension in `--filename`.  Be aware that if you do not specify `--format=csv`, then the extension\format will be `json`, which means that any filename you specify will include the extension of `.json`.
+
 
 
 1.64

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ mintapi --headless john@example.com my_password
 
 ### MFA Authentication Methods
 
-As of v1.62, `mfa_method` is only required if your login flow presents you with the option to select which Multifactor Authentication Method you wish to use, typically as a result of your account configured to accept different methods.  
+As of v2.0, `mfa_method` is only required if your login flow presents you with the option to select which Multifactor Authentication Method you wish to use, typically as a result of your account configured to accept different methods.  
 
 If `mintapi` detects that your Mint account uses IMAP and your email host provides IMAP access, you can specify your IMAP login details.  This will automate the retrieval of the MFA code from your email and entering it into Mint.  If you use IMAP in conjunction with `keyring`, then you can store your IMAP password (`imap-password`) in keyring.  To do so, simply omit `imap-password` and you will initially be prompted for the password associated with your IMAP account.  Then, on subsequent uses of your IMAP account, you will not have to specify your password.
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,13 @@ mintapi --headless john@example.com my_password
 
 ### MFA Authentication Methods
 
-If `mfa-method` is email and your email host provides IMAP access, you can specify your IMAP login details.
-This will automate the retrieval of the MFA code from your email and entering it into Mint.  If you use IMAP in conjunction with `keyring`, then you can store your IMAP password (`imap-password`) in keyring.  To do so, simply omit `imap-password` and you will initially be prompted for the password associated with your IMAP account.  Then, on subsequent uses of your IMAP account, you will not have to specify your password.
+As of v1.62, `mfa_method` is only required if your login flow presents you with the option to select which Multifactor Authentication Method you wish to use, typically as a result of your account configured to accept different methods.  
+
+If `mintapi` detects that your Mint account uses IMAP and your email host provides IMAP access, you can specify your IMAP login details.  This will automate the retrieval of the MFA code from your email and entering it into Mint.  If you use IMAP in conjunction with `keyring`, then you can store your IMAP password (`imap-password`) in keyring.  To do so, simply omit `imap-password` and you will initially be prompted for the password associated with your IMAP account.  Then, on subsequent uses of your IMAP account, you will not have to specify your password.
 
 If `mfa-method` is soft-token then you must also pass your `mfa-token`. The `mfa-token` can be obtained by going to [your mint.com settings](https://mint.intuit.com/settings.event?filter=all) and clicking on 'Intuit Account'. From there go to *Sign In & Security* -> *Two-step verification*. From there, enable the top option however you wish (either text or email is fine). After that, start the process to enable the *Authenticator app* option and when you get the part where you see the QR code, **copy the manual setup code** that appears next to it. Careful where you store this as it allows anyone to generate TOTP codes. This is the token that you will pass to `mfa-token` in either the python api or from the command line.
+
+While Mint supports authentication via Voice, `mintapi` does not currently support this option.  Compatability with this method will be added in a later version.
 
 ### from Python
 

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -206,7 +206,7 @@ def parse_arguments(args):
             ("--mfa-method",),
             {
                 "choices": ["sms", "email", "soft-token"],
-                "default": "sms",
+                "default": None,
                 "help": "The MFA method to automate.",
             },
         ),
@@ -403,7 +403,7 @@ def main():
         "mintapi", "Mint password: ", email, password, options.keyring
     )
 
-    if mfa_method == "email" and imap_account:
+    if imap_account:
         imap_password = handle_password(
             "mintapi_imap",
             "IMAP password: ",

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -485,8 +485,13 @@ def sign_in(
             driver.find_element_by_id(
                 "ius-sign-in-mfa-password-collection-continue-btn"
             ).submit()
-        except (NoSuchElementException, ElementNotInteractableException):
+        except (
+            NoSuchElementException,
+            StaleElementReferenceException,
+            ElementNotInteractableException,
+        ):
             pass  # not on secondary mfa password screen
+
     driver.implicitly_wait(20)  # seconds
 
     # Wait until the overview page has actually loaded, and if wait_for_sync==True, sync has completed.

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -46,27 +46,23 @@ def get_email_code(
     try:
         imap_client = imaplib.IMAP4_SSL(imap_server)
     except imaplib.IMAP4.error:
-        logger.error("ERROR: Unable to establish IMAP Client")
-        return ""
+        raise RuntimeError("Unable to establish IMAP Client")
 
     try:
         rv, data = imap_client.login(imap_account, imap_password)
     except imaplib.IMAP4.error:
-        logger.error("ERROR: email login failed")
-        return ""
+        raise RuntimeError("Unable to login to IMAP Email")
 
     code = ""
     for c in range(20):
         time.sleep(10)
         rv, data = imap_client.select(imap_folder)
         if rv != "OK":
-            logger.error("ERROR: Unable to open mailbox ", rv)
-            return ""
+            raise RuntimeError("Unable to open mailbox: " + rv)
 
         rv, data = imap_client.search(None, "ALL")
         if rv != "OK":
-            logger.error("ERROR: Email search failed")
-            return ""
+            raise RuntimeError("Unable to search the Email folder: " + rv)
 
         count = 0
         for num in data[0].split()[::-1]:
@@ -75,8 +71,7 @@ def get_email_code(
                 break
             rv, data = imap_client.fetch(num, "(RFC822)")
             if rv != "OK":
-                logger.error("ERROR: ERROR getting message", num)
-                sys.exit(1)
+                raise RuntimeError("Unable to complete due to error message: " + rv)
 
             msg = email.message_from_bytes(data[0][1])
 
@@ -312,6 +307,43 @@ def sign_in(
     )
     driver.implicitly_wait(0)  # seconds
 
+    user_selection_page(driver)
+
+    try:  # try to enter in credentials if username and password are on same page
+        handle_same_page_username_password(driver, email, password)
+    # try to enter in credentials if username and password are on different pages
+    except (ElementNotInteractableException, ElementNotVisibleException):
+        handle_different_page_username_password(driver, email, password)
+        driver.implicitly_wait(20)  # seconds
+        password_page(driver, password)
+
+    # Wait until logged in, just in case we need to deal with MFA.
+    driver.implicitly_wait(1)  # seconds
+    while not driver.current_url.startswith("https://mint.intuit.com/overview.event"):
+        bypass_verified_user_page(driver)
+        mfa_page(
+            driver,
+            mfa_method,
+            mfa_token,
+            mfa_input_callback,
+            imap_account,
+            imap_password,
+            imap_server,
+            imap_folder,
+        )
+        account_selection_page(driver, intuit_account)
+        password_page(driver, password)
+
+    driver.implicitly_wait(20)  # seconds
+
+    # Wait until the overview page has actually loaded, and if wait_for_sync==True, sync has completed.
+    status_message = None
+    if wait_for_sync:
+        handle_wait_for_sync(driver, wait_for_sync_timeout)
+    return status_message, get_token(driver)
+
+
+def user_selection_page(driver):
     # click "Use a different user ID" if needed
     try:
         driver.find_element_by_id("ius-link-use-a-different-id-known-device").click()
@@ -323,199 +355,194 @@ def sign_in(
     except NoSuchElementException:
         pass
 
-    try:  # try to enter in credentials if username and password are on same page
-        email_input = driver.find_element_by_id("ius-userid")
+
+def handle_same_page_username_password(driver, email, password):
+    email_input = driver.find_element_by_id("ius-userid")
+    if not email_input.is_displayed():
+        raise ElementNotVisibleException()
+    email_input.clear()  # clear email and user specified email
+    email_input.send_keys(email)
+    driver.find_element_by_id("ius-password").send_keys(password)
+    driver.find_element_by_id("ius-sign-in-submit-btn").submit()
+
+
+def handle_different_page_username_password(driver, email, password):
+    try:
+        email_input = driver.find_element_by_id("ius-identifier")
         if not email_input.is_displayed():
             raise ElementNotVisibleException()
-        email_input.clear()  # clear email and user specified email
+        email_input.clear()  # clear email and use specified email
         email_input.send_keys(email)
-        driver.find_element_by_id("ius-password").send_keys(password)
-        driver.find_element_by_id("ius-sign-in-submit-btn").submit()
-    # try to enter in credentials if username and password are on different pages
+        driver.find_element_by_id("ius-sign-in-submit-btn").click()
+    # click on username if on the saved usernames page
     except (ElementNotInteractableException, ElementNotVisibleException):
-        try:
-            email_input = driver.find_element_by_id("ius-identifier")
-            if not email_input.is_displayed():
-                raise ElementNotVisibleException()
-            email_input.clear()  # clear email and use specified email
-            email_input.send_keys(email)
-            driver.find_element_by_id("ius-sign-in-submit-btn").click()
-        # click on username if on the saved usernames page
-        except (ElementNotInteractableException, ElementNotVisibleException):
-            username_elements = driver.find_elements_by_class_name(
-                "ius-option-username"
+        username_elements = driver.find_elements_by_class_name("ius-option-username")
+        for username_element in username_elements:
+            if username_element.text == email:
+                username_element.click()
+                break
+
+
+def bypass_verified_user_page(driver):
+    # bypass "Let's add your current mobile number" interstitial page
+    try:
+        skip_for_now = driver.find_element_by_id("ius-verified-user-update-btn-skip")
+        skip_for_now.click()
+    except (
+        NoSuchElementException,
+        StaleElementReferenceException,
+        ElementNotVisibleException,
+    ):
+        pass
+
+
+def mfa_page(
+    driver,
+    mfa_method,
+    mfa_token,
+    mfa_input_callback,
+    imap_account,
+    imap_password,
+    imap_server,
+    imap_folder,
+):
+    # mfa screen
+    try:
+        if mfa_method == "soft-token":
+            mfa_token_input = driver.find_element_by_css_selector(
+                "#iux-mfa-soft-token-verification-code, #ius-mfa-soft-token"
             )
-            for username_element in username_elements:
-                if username_element.text == email:
-                    username_element.click()
-                    break
-        driver.implicitly_wait(20)  # seconds
-        try:
-            driver.find_element_by_id(
-                "ius-sign-in-mfa-password-collection-current-password"
-            ).send_keys(password)
-            driver.find_element_by_id(
-                "ius-sign-in-mfa-password-collection-continue-btn"
-            ).submit()
-        except NoSuchElementException:
-            pass  # password may not be here when using MFA
-
-    # Wait until logged in, just in case we need to deal with MFA.
-    driver.implicitly_wait(1)  # seconds
-    while not driver.current_url.startswith("https://mint.intuit.com/overview.event"):
-
-        # bypass "Let's add your current mobile number" interstitial page
-        try:
-            skip_for_now = driver.find_element_by_id(
-                "ius-verified-user-update-btn-skip"
+            if mfa_input_callback is not None:
+                mfa_code = mfa_input_callback("Please enter your 6-digit MFA code: ")
+            else:
+                mfa_code = oathtool.generate_otp(mfa_token)
+            mfa_token_input.send_keys(mfa_code)
+            mfa_token_submit = driver.find_element_by_css_selector(
+                '#ius-mfa-soft-token-submit-btn, [data-testid="VerifySoftTokenSubmitButton"]'
             )
-            skip_for_now.click()
-        except (
-            NoSuchElementException,
-            StaleElementReferenceException,
-            ElementNotVisibleException,
-        ):
-            pass
-
-        # mfa screen
-        try:
-            if mfa_method == "soft-token":
-                mfa_token_input = driver.find_element_by_css_selector(
-                    "#iux-mfa-soft-token-verification-code, #ius-mfa-soft-token"
+            mfa_token_submit.click()
+        else:
+            try:
+                driver.find_element_by_id("ius-mfa-options-form")
+                mfa_method_option = driver.find_element_by_id(
+                    "ius-mfa-option-{}".format(mfa_method)
                 )
-                if mfa_input_callback is not None:
-                    mfa_code = mfa_input_callback(
-                        "Please enter your 6-digit MFA code: "
+                mfa_method_option.click()
+                mfa_method_submit = driver.find_element_by_id(
+                    "ius-mfa-options-submit-btn"
+                )
+                mfa_method_submit.click()
+            except NoSuchElementException:
+                pass  # no option to select mfa option
+
+            if mfa_method == "email" and imap_account:
+                for element_id in [
+                    "ius-label-mfa-email-otp",
+                    "ius-mfa-email-otp-card-challenge",
+                    "ius-sublabel-mfa-email-otp",
+                ]:
+                    try:
+                        mfa_email_select = driver.find_element_by_id(element_id)
+                        mfa_email_select.click()
+                        break
+                    except (
+                        NoSuchElementException,
+                        ElementNotInteractableException,
+                    ):
+                        pass  # no option to select email address
+
+            if mfa_method == "sms":
+                try:
+                    mfa_sms_select = driver.find_element_by_id(
+                        "ius-mfa-sms-otp-card-challenge"
+                    )
+                    mfa_sms_select.click()
+                except (NoSuchElementException, ElementNotInteractableException):
+                    pass  # no option to select sms
+
+            try:
+                mfa_code_input = driver.find_element_by_id("ius-mfa-confirm-code")
+                mfa_code_input.clear()
+                if mfa_method == "email" and imap_account:
+                    mfa_code = get_email_code(
+                        imap_account,
+                        imap_password,
+                        imap_server,
+                        imap_folder=imap_folder,
                     )
                 else:
-                    mfa_code = oathtool.generate_otp(mfa_token)
-                mfa_token_input.send_keys(mfa_code)
-                mfa_token_submit = driver.find_element_by_css_selector(
-                    '#ius-mfa-soft-token-submit-btn, [data-testid="VerifySoftTokenSubmitButton"]'
+                    mfa_code = (mfa_input_callback or input)(
+                        "Please enter your 6-digit MFA code: "
+                    )
+                mfa_code_input.send_keys(mfa_code)
+
+                mfa_code_submit = driver.find_element_by_css_selector(
+                    '#ius-mfa-otp-submit-btn, [data-testid="VerifyOtpSubmitButton"]'
                 )
-                mfa_token_submit.click()
-            else:
-                try:
-                    driver.find_element_by_id("ius-mfa-options-form")
-                    mfa_method_option = driver.find_element_by_id(
-                        "ius-mfa-option-{}".format(mfa_method)
-                    )
-                    mfa_method_option.click()
-                    mfa_method_submit = driver.find_element_by_id(
-                        "ius-mfa-options-submit-btn"
-                    )
-                    mfa_method_submit.click()
-                except NoSuchElementException:
-                    pass  # no option to select mfa option
+                mfa_code_submit.click()
+            except (NoSuchElementException, ElementNotInteractableException):
+                pass  # we're not on mfa input screen
 
-                if mfa_method == "email" and imap_account:
-                    for element_id in [
-                        "ius-label-mfa-email-otp",
-                        "ius-mfa-email-otp-card-challenge",
-                        "ius-sublabel-mfa-email-otp",
-                    ]:
-                        try:
-                            mfa_email_select = driver.find_element_by_id(element_id)
-                            mfa_email_select.click()
-                            break
-                        except (
-                            NoSuchElementException,
-                            ElementNotInteractableException,
-                        ):
-                            pass  # no option to select email address
+    except NoSuchElementException:
+        pass  # not on mfa screen
 
-                if mfa_method == "sms":
-                    try:
-                        mfa_sms_select = driver.find_element_by_id(
-                            "ius-mfa-sms-otp-card-challenge"
-                        )
-                        mfa_sms_select.click()
-                    except (NoSuchElementException, ElementNotInteractableException):
-                        pass  # no option to select sms
 
-                try:
-                    mfa_code_input = driver.find_element_by_id("ius-mfa-confirm-code")
-                    mfa_code_input.clear()
-                    if mfa_method == "email" and imap_account:
-                        mfa_code = get_email_code(
-                            imap_account,
-                            imap_password,
-                            imap_server,
-                            imap_folder=imap_folder,
-                        )
-                    else:
-                        mfa_code = (mfa_input_callback or input)(
-                            "Please enter your 6-digit MFA code: "
-                        )
-                    mfa_code_input.send_keys(mfa_code)
-
-                    mfa_code_submit = driver.find_element_by_css_selector(
-                        '#ius-mfa-otp-submit-btn, [data-testid="VerifyOtpSubmitButton"]'
-                    )
-                    mfa_code_submit.click()
-                except (NoSuchElementException, ElementNotInteractableException):
-                    pass  # we're not on mfa input screen
-
-        except NoSuchElementException:
-            pass  # not on mfa screen
-
-        # account selection screen -- if there are multiple accounts, select one
-        try:
-            select_account = driver.find_element_by_id("ius-mfa-select-account-section")
-            if intuit_account is not None:
-                account_input = select_account.find_element_by_xpath(
-                    "//label/span[text()='{}']/../preceding-sibling::input".format(
-                        intuit_account
-                    )
-                )
-                account_input.click()
-
-            mfa_code_submit = driver.find_element_by_css_selector(
-                '#ius-sign-in-mfa-select-account-continue-btn, [data-testid="SelectAccountContinueButton"]'
-            )
-            mfa_code_submit.click()
-        except NoSuchElementException:
-            pass  # not on account selection screen
-
-        # password only sometimes after mfa
-        try:
-            driver.find_element_by_id(
-                "ius-sign-in-mfa-password-collection-current-password"
-            ).send_keys(password)
-            driver.find_element_by_id(
-                "ius-sign-in-mfa-password-collection-continue-btn"
-            ).submit()
-        except (
-            NoSuchElementException,
-            StaleElementReferenceException,
-            ElementNotInteractableException,
-        ):
-            pass  # not on secondary mfa password screen
-
-    driver.implicitly_wait(20)  # seconds
-
-    # Wait until the overview page has actually loaded, and if wait_for_sync==True, sync has completed.
-    status_message = None
-    if wait_for_sync:
-        try:
-            # Status message might not be present straight away. Seems to be due
-            # to dynamic content (client side rendering).
-            status_web_element = WebDriverWait(driver, 30).until(
-                expected_conditions.visibility_of_element_located(
-                    (By.CSS_SELECTOR, ".SummaryView .message")
+def account_selection_page(driver, intuit_account):
+    # account selection screen -- if there are multiple accounts, select one
+    try:
+        select_account = driver.find_element_by_id("ius-mfa-select-account-section")
+        if intuit_account is not None:
+            account_input = select_account.find_element_by_xpath(
+                "//label/span[text()='{}']/../preceding-sibling::input".format(
+                    intuit_account
                 )
             )
-            WebDriverWait(driver, wait_for_sync_timeout).until(
-                lambda x: "Account refresh complete"
-                in status_web_element.get_attribute("innerHTML")
+            account_input.click()
+
+        mfa_code_submit = driver.find_element_by_css_selector(
+            '#ius-sign-in-mfa-select-account-continue-btn, [data-testid="SelectAccountContinueButton"]'
+        )
+        mfa_code_submit.click()
+    except NoSuchElementException:
+        pass  # not on account selection screen
+
+
+def password_page(driver, password):
+    # password only sometimes after mfa
+    try:
+        driver.find_element_by_id(
+            "ius-sign-in-mfa-password-collection-current-password"
+        ).send_keys(password)
+        driver.find_element_by_id(
+            "ius-sign-in-mfa-password-collection-continue-btn"
+        ).submit()
+    except (
+        NoSuchElementException,
+        StaleElementReferenceException,
+        ElementNotInteractableException,
+    ):
+        pass  # not on secondary mfa password screen
+
+
+def handle_wait_for_sync(driver, wait_for_sync_timeout):
+    try:
+        # Status message might not be present straight away. Seems to be due
+        # to dynamic content (client side rendering).
+        status_web_element = WebDriverWait(driver, 30).until(
+            expected_conditions.visibility_of_element_located(
+                (By.CSS_SELECTOR, ".SummaryView .message")
             )
-            status_message = status_web_element.text
-        except (TimeoutException, StaleElementReferenceException):
-            logger.warning(
-                "Mint sync apparently incomplete after timeout. "
-                "Data retrieved may not be current."
-            )
-    return status_message, get_token(driver)
+        )
+        WebDriverWait(driver, wait_for_sync_timeout).until(
+            lambda x: "Account refresh complete"
+            in status_web_element.get_attribute("innerHTML")
+        )
+        status_message = status_web_element.text
+    except (TimeoutException, StaleElementReferenceException):
+        logger.warning(
+            "Mint sync apparently incomplete after timeout. "
+            "Data retrieved may not be current."
+        )
 
 
 def get_web_driver(

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -358,7 +358,7 @@ def sign_in(
             handle_same_page_username_password(driver, email, password)
         # try to enter in credentials if username and password are on different pages
         except (
-            ElementNotInteractableException, 
+            ElementNotInteractableException,
             ElementNotVisibleException,
             NoSuchElementException,
         ):
@@ -483,6 +483,10 @@ def mfa_page(
     mfa_token_input = mfa_result[0]
     mfa_token_button = mfa_result[1]
     mfa_method = mfa_result[2]
+    if mfa_method is None:
+        # MFA is optional for devices that were registered to Mint by clicking on "Remember my device"
+        logger.info("Your Mint Account does not require Multifactor Authentication.")
+        return
 
     # mfa screen
     if mfa_method == MFA_VIA_SOFT_TOKEN:
@@ -542,7 +546,9 @@ def set_mfa_method(driver, mfa_method):
         )
         mfa_method = mfa_result[MFA_METHOD_LABEL]
     except (NoSuchElementException, ElementNotInteractableException):
-        raise RuntimeError("The Multifactor Method supplied is not available.")
+        raise RuntimeError(
+            "The Multifactor Method {} supplied is not available.".format(mfa_method)
+        )
     return mfa_token_input, mfa_token_button, mfa_method
 
 

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -314,6 +314,7 @@ def _create_web_driver_at_mint_com(
 
 
 def get_token(driver: Chrome):
+    driver.implicitly_wait(600)
     value_json = driver.find_element_by_name("javascript-user").get_attribute("value")
     return json.loads(value_json)["token"]
 
@@ -353,7 +354,7 @@ def sign_in(
 
     user_selection_page(driver)
 
-    while not driver.current_url.startswith("https://mint.intuit.com/overview.event"):
+    while not driver.current_url.startswith("https://mint.intuit.com/overview"):
         try:  # try to enter in credentials if username and password are on same page
             handle_same_page_username_password(driver, email, password)
         # try to enter in credentials if username and password are on different pages


### PR DESCRIPTION
Currently, we rely on user-submitted `mfa_method` to match with the configured settings in Mint.  This can lead to a lot of confusion surrounding correct flow and often leads to a bit of troubleshooting when login doesn't work as expected.  The submitted approach does the following:

* A new array, `MFA_METHODS`, is available to control which Multifactor Authentication methods are available and the corresponding CSS elements on the screen.
* Because of the opportunity for Mint to prompt the user to select a Multifactor Authentication method, we are preserving the `mfa_method` argument and pass it to `mfa_selection_page` in the case that the relevant UI Components exist on the screen.
* In the case that `mfa_method` is supplied, we search `MFA_METHODS` for the resulting method and locate the CSS elements that should exist on the screen.
* In the case that `mfa_method` is not supplied, we loop through `MFA_METHODS` looking for matches of the CSS elements on the screen.  Once we find one, we proceed with the key for `mfa_method`, the input element on the screen, and the button element on the screen.
* Lastly, we pass each of those to individual methods based on if an One-Time Password (OTP) is required (`soft-token`), an email onscreen with IMAP configured, or any other type of Multifactor Authentication code.

This should fix #291 and fix #254.