### PR TITLE
Improve error handling for verified user bypass

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -392,6 +392,7 @@ def bypass_verified_user_page(driver):
         NoSuchElementException,
         StaleElementReferenceException,
         ElementNotVisibleException,
+        ElementNotInteractableException,
     ):
         pass
 


### PR DESCRIPTION
`skip_for_now.click()` is raising an `ElementNotInteractableException` for me.