### PR TITLE
Re-throw exception during login

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -248,8 +248,11 @@ class Mint(object):
                 imap_folder,
             )
         except Exception as e:
+            msg = f"Could not sign in to Mint. Current page: {self.driver.current_url}"
             logger.exception(e)
             self.driver.quit()
+            self.driver = None
+            raise Exception(msg) from e
 
     def get_request_id_str(self):
         req_id = self.request_id

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -308,8 +308,10 @@ class MintApiTests(unittest.TestCase):
     ):
         test_exception = Exception()
         mock_sign_in.side_effect = test_exception
-        mintapi.Mint("test", "test")
+        with self.assertRaises(Exception) as context:
+            mintapi.Mint("test", "test")
         mock_logger.exception.assert_called_with(test_exception)
+        self.assertTrue("Could not sign in to Mint" in str(context.exception))
 
     @patch.multiple(
         mintapi.Mint,


### PR DESCRIPTION
By silencing the exception in the `login_and_get_token` the code execution could still continue without an explicit try-except which would could end up additional calls to a `WebDriver` that was already closed (by `quit()`) that leads to confusing error messages (similar to `MaxRetryError("HTTPConnectionPool(host='127.0.0.1', port=55873): Max retries exceeded with url: /session/2dd60780e17e5d8d8e1cdf9496086729/window_handles`)

Could be related to issue: #387