### PR TITLE
Update overview page url

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -323,7 +323,7 @@ def sign_in(
 
     # Wait until logged in, just in case we need to deal with MFA.
     driver.implicitly_wait(1)  # seconds
-    while not driver.current_url.startswith("https://mint.intuit.com/overview.event"):
+    while not driver.current_url.startswith("https://mint.intuit.com/overview"):
         bypass_verified_user_page(driver)
         mfa_page(
             driver,

--- a/tests/test_endpoints_sign_in.py
+++ b/tests/test_endpoints_sign_in.py
@@ -65,7 +65,7 @@ def test_sign_in(get_mint_driver: mintapi.Mint):
         INTUIT_ACCOUNT,
     )
     assert get_mint_driver.driver.current_url.startswith(
-        "https://mint.intuit.com/overview.event"
+        "https://mint.intuit.com/overview"
     )
 
 


### PR DESCRIPTION
For me, the overview page no longer has ".event" at the end, so mintapi hangs here.