### PR TITLE
[CHORE] - Change the name of the Account Refresh Class

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -542,7 +542,7 @@ def handle_wait_for_sync(driver, wait_for_sync_timeout):
         # to dynamic content (client side rendering).
         status_web_element = WebDriverWait(driver, 30).until(
             expected_conditions.visibility_of_element_located(
-                (By.CSS_SELECTOR, ".SummaryView .message")
+                (By.CSS_SELECTOR, ".AccountStatusBar")
             )
         )
         WebDriverWait(driver, wait_for_sync_timeout).until(


### PR DESCRIPTION
As part of the rollout of Mint's new UI, one of the changes is the class associated with the "Account Refresh" component at the bottom of the home screen after login.  This PR addresses that name change so that the Refresh method will not timeout.

NOTE: There is still an issue with the `get_token` method.  This does not attempt to fix that method.