### PR TITLE
Update selenium dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         "oathtool",
         "pandas>=1.0",
         "requests",
-        "selenium<4.0.0",
+        "selenium<5.0.0",
         "selenium-requests>=1.3.3",
         "xmltodict",
         "keyring",


### PR DESCRIPTION
The <4.0.0 restriction was to satisfy the version requirements of selenium_requests.
selenium_requests now supports selenium 4.1.0 as of the [1.4.0 release](https://github.com/cryzed/Selenium-Requests/releases/tag/v1.4.0)

resolves #412, resolves #413

Figured I'll put this out there and leave it up to you if you want to merge :)