### PR TITLE
[FIX] - Use the new location of the Mint API Key

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -144,7 +144,7 @@ class Mint(object):
         ).zfill(3)
 
     def _get_api_key_header(self):
-        key_var = "window.MintConfig.browserAuthAPIKey"
+        key_var = "__shellInternal.OILConfigs.key"
         api_key = self.driver.execute_script("return " + key_var)
         auth = "Intuit_APIKey intuit_apikey=" + api_key
         auth += ", intuit_apikey_version=1.0"


### PR DESCRIPTION
This is the next part of a series of fixes required based on the new layout and flow of Mint.  In the update, their scripts changed and so the location of the API Key changed.  

NOTE: This doesn't completely fix the problems that users are experiencing, but is one necessary step in the process.