### PR TITLE
[FIX] - Remove deprecated get_token functionality

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -91,7 +91,6 @@ class MintException(Exception):
 
 class Mint(object):
     request_id = 42  # magic number? random number?
-    token = None
     driver = None
     status_message = None
 
@@ -203,8 +202,8 @@ class Mint(object):
         return response
 
     def build_bundledServiceController_url(self):
-        return "{}/bundledServiceController.xevent?legacy=false&token={}".format(
-            MINT_ROOT_URL, self.token
+        return "{}/bundledServiceController.xevent?legacy=false".format(
+            MINT_ROOT_URL
         )
 
     def login_and_get_token(
@@ -232,7 +231,7 @@ class Mint(object):
         )
 
         try:
-            self.status_message, self.token = sign_in(
+            self.status_message = sign_in(
                 email,
                 password,
                 self.driver,
@@ -717,9 +716,8 @@ class Mint(object):
         return {"id": parent["id"], "name": parent["name"]}
 
     def initiate_account_refresh(self):
-        data = {"token": self.token}
         self.make_post_request(
-            url="{}/refreshFILogins.xevent".format(MINT_ROOT_URL), data=data
+            url="{}/refreshFILogins.xevent".format(MINT_ROOT_URL)
         )
 
     def get_credit_score(self):

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -202,9 +202,7 @@ class Mint(object):
         return response
 
     def build_bundledServiceController_url(self):
-        return "{}/bundledServiceController.xevent?legacy=false".format(
-            MINT_ROOT_URL
-        )
+        return "{}/bundledServiceController.xevent?legacy=false".format(MINT_ROOT_URL)
 
     def login_and_get_token(
         self,
@@ -716,9 +714,7 @@ class Mint(object):
         return {"id": parent["id"], "name": parent["name"]}
 
     def initiate_account_refresh(self):
-        self.make_post_request(
-            url="{}/refreshFILogins.xevent".format(MINT_ROOT_URL)
-        )
+        self.make_post_request(url="{}/refreshFILogins.xevent".format(MINT_ROOT_URL))
 
     def get_credit_score(self):
         # Request a single credit report, and extract the score

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -323,7 +323,7 @@ def sign_in(
 
     # Wait until logged in, just in case we need to deal with MFA.
     driver.implicitly_wait(1)  # seconds
-    while not driver.current_url.startswith("https://mint.intuit.com/overview.event"):
+    while not driver.current_url.startswith("https://mint.intuit.com/overview"):
         bypass_verified_user_page(driver)
         mfa_page(
             driver,

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -269,11 +269,6 @@ def _create_web_driver_at_mint_com(
     return driver
 
 
-def get_token(driver: Chrome):
-    value_json = driver.find_element_by_name("javascript-user").get_attribute("value")
-    return json.loads(value_json)["token"]
-
-
 def sign_in(
     email,
     password,
@@ -344,7 +339,7 @@ def sign_in(
     status_message = None
     if wait_for_sync:
         handle_wait_for_sync(driver, wait_for_sync_timeout)
-    return status_message, get_token(driver)
+    return status_message
 
 
 def user_selection_page(driver):

--- a/tests/test_endpoints_sign_in.py
+++ b/tests/test_endpoints_sign_in.py
@@ -65,7 +65,7 @@ def test_sign_in(get_mint_driver: mintapi.Mint):
         INTUIT_ACCOUNT,
     )
     assert get_mint_driver.driver.current_url.startswith(
-        "https://mint.intuit.com/overview.event"
+        "https://mint.intuit.com/overview"
     )
 
 


### PR DESCRIPTION
This is another part of a series of fixes required based on the new layout and flow of Mint. In the update, we no longer could reference an element called `javascript-user` to pull a token.  All API Requests use the API Key header as authentication so we can simply remove the `get_token` functionality.

NOTE: This doesn't completely fix the problems that users are experiencing, but is one necessary step in the process.