### PR TITLE
[FIX] - Use the correct field for the API Token

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -143,7 +143,7 @@ class Mint(object):
         ).zfill(3)
 
     def _get_api_key_header(self):
-        key_var = "__shellInternal.OILConfigs.key"
+        key_var = "window.__shellInternal.appExperience.appApiKey"
         api_key = self.driver.execute_script("return " + key_var)
         auth = "Intuit_APIKey intuit_apikey=" + api_key
         auth += ", intuit_apikey_version=1.0"


### PR DESCRIPTION
PR #420 attempted to return the API Key from the new location.  However, after further testing, I discovered the wrong return value was being used.  This PR uses the correct reference.