### PR TITLE
🔨 - Remove support for hiding duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ make calls to retrieve account/budget information.  We recommend using the
   # Get transactions
   mint.get_transactions() # as pandas dataframe
   mint.get_transactions_csv(include_investment=False) # as raw csv data
-  mint.get_transactions_json(include_investment=False, skip_duplicates=False)
+  mint.get_transactions_json(include_investment=False)
 
   # Get transactions for a specific account
   accounts = mint.get_accounts(True)
@@ -187,7 +187,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                    [--extended-transactions] [--credit-score] [--credit-report]
                    [--exclude-inquiries] [--exclude-accounts] [--exclude-utilization]
                    [--start-date [START_DATE]] [--end-date [END_DATE]]
-                   [--include-investment] [--skip-duplicates] [--show-pending]
+                   [--include-investment] [--show-pending]
                    [--filename FILENAME] [--keyring] [--headless] [--attention]
                    [--mfa-method {sms,email,soft-token}]
                    [--categories]
@@ -228,7 +228,6 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                             Used with --transactions or --extended-transactions. Format: mm/dd/yy
       --investments         Retrieve data related to your investments, whether they be retirement or         personal stock purchases
       --include-investment  Used with --extended-transactions
-      --skip-duplicates     Used with --extended-transactions
       --show-pending        Exclude pending transactions from being retrieved.
                             Used with --extended-transactions
       --filename FILENAME, -f FILENAME

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -249,14 +249,6 @@ def parse_arguments(args):
             },
         ),
         (
-            ("--skip-duplicates",),
-            {
-                "action": "store_true",
-                "default": False,
-                "help": "Used with --extended-transactions",
-            },
-        ),
-        (
             ("--start-date",),
             {
                 "nargs": "?",
@@ -509,7 +501,6 @@ def main():
             end_date=options.end_date,
             include_investment=options.include_investment,
             remove_pending=options.show_pending,
-            skip_duplicates=options.skip_duplicates,
         )
     elif options.categories:
         data = mint.get_categories()


### PR DESCRIPTION
After reviewing Mint's new UI, there is no trace of support for hiding duplicate transactions.  As a result, we are removing support for the functionality from Mintapi.