### PR TITLE
 🔨 - Update Transactions Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,12 @@ make calls to retrieve account/budget information.  We recommend using the
   mint.get_budgets()
 
   # Get transactions
-  mint.get_transactions() # as pandas dataframe
-  mint.get_transactions_csv(include_investment=False) # as raw csv data
-  mint.get_transactions_json(include_investment=False)
+  mint.get_transaction_data() # as pandas dataframe
 
   # Get transactions for a specific account
   accounts = mint.get_accounts(True)
   for account in accounts:
-    mint.get_transactions_csv(id=account["id"])
-    mint.get_transactions_json(id=account["id"])
+    mint.get_transaction_data(id=account["id"])
 
   # Get net worth
   mint.get_net_worth()
@@ -175,7 +172,7 @@ make calls to retrieve account/budget information.  We recommend using the
   )
   # now you can do all the normal api calls
   # ex:
-  mint.get_transactions()
+  mint.get_transaction_data()
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ an MFA prompt, you'll be prompted on the command line for your code, which by de
 goes to SMS unless you specify `--mfa-method=email`. This will also persist a browser
 session in $HOME/.mintapi/session to avoid an MFA in the future, unless you specify `--session-path=None`.
 
-If you wish to simplify the number of arguments passed in the command line, you can use a configuration file by specifying `--config-file`.  For arguments such as `--extended-transactions`, you can add a line in your config file that says `extended-transactions`.  For other arguments that have input, such as `--start-date`, you would add a line such as `start-date=10/01/21`.  There are two exceptions to what you can add to the config file: email and password.  Since these arguments do not include `--`, you cannot add them to the config file.
+If you wish to simplify the number of arguments passed in the command line, you can use a configuration file by specifying `--config-file`.  For arguments such as `--transactions`, you can add a line in your config file that says `transactions`.  For other arguments that have input, such as `--start-date`, you would add a line such as `start-date=10/01/21`.  There are two exceptions to what you can add to the config file: email and password.  Since these arguments do not include `--`, you cannot add them to the config file.
 
 ### Linux Distributions (including Raspberry Pi OS)
 
@@ -183,8 +183,8 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
 
 ```shell
     usage: mintapi [-h] [--session-path [SESSION_PATH]] [--accounts] [--investment]
-                   [--budgets | --budget_hist] [--net-worth] [--extended-accounts] [--transactions]
-                   [--extended-transactions] [--credit-score] [--credit-report]
+                   [--budgets | --budget_hist] [--net-worth] [--extended-accounts] 
+                   [--transactions] [--credit-score] [--credit-report]
                    [--exclude-inquiries] [--exclude-accounts] [--exclude-utilization]
                    [--start-date [START_DATE]] [--end-date [END_DATE]]
                    [--include-investment] [--show-pending]
@@ -217,19 +217,16 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
       --net-worth           Retrieve net worth information
       --extended-accounts   Retrieve extended account information (slower, implies --accounts)
       --transactions, -t    Retrieve transactions
-      --extended-transactions
-                            Retrieve transactions with extra information and
-                            arguments
       --start-date [START_DATE]
                             Earliest date for which to retrieve transactions.
-                            Used with --transactions or --extended-transactions. Format: mm/dd/yy
+                            Used with --transactions. Format: mm/dd/yy
       --end-date [END_DATE]
                             Latest date for which to retrieve transactions.
-                            Used with --transactions or --extended-transactions. Format: mm/dd/yy
+                            Used with --transactions. Format: mm/dd/yy
       --investments         Retrieve data related to your investments, whether they be retirement or         personal stock purchases
-      --include-investment  Used with --extended-transactions
+      --include-investment  Used with --transactions
       --show-pending        Exclude pending transactions from being retrieved.
-                            Used with --extended-transactions
+                            Used with --transactions
       --filename FILENAME, -f FILENAME
                             write results to file. can be {csv,json} format.
                             default is to write to stdout.

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -114,7 +114,7 @@ def parse_arguments(args):
             {
                 "nargs": "?",
                 "default": None,
-                "help": "Latest date for transactions to be retrieved from. Used with --transactions or --extended-transactions. Format: mm/dd/yy",
+                "help": "Latest date for transactions to be retrieved from. Used with --transactions. Format: mm/dd/yy",
             },
         ),
         (
@@ -151,14 +151,6 @@ def parse_arguments(args):
             },
         ),
         (
-            ("--extended-transactions",),
-            {
-                "action": "store_true",
-                "default": False,
-                "help": "Retrieve transactions with extra information and arguments",
-            },
-        ),
-        (
             ("--filename", "-f"),
             {
                 "help": "write results to file. can be {csv,json} format. default is to write to stdout."
@@ -192,7 +184,7 @@ def parse_arguments(args):
             {
                 "action": "store_true",
                 "default": False,
-                "help": "Used with --extended-transactions",
+                "help": "Used with --transactions",
             },
         ),
         (
@@ -245,7 +237,7 @@ def parse_arguments(args):
             {
                 "action": "store_false",
                 "default": True,
-                "help": "Exclude pending transactions from being retrieved. Used with --extended-transactions",
+                "help": "Exclude pending transactions from being retrieved. Used with --transactions",
             },
         ),
         (
@@ -253,7 +245,7 @@ def parse_arguments(args):
             {
                 "nargs": "?",
                 "default": None,
-                "help": "Earliest date for transactions to be retrieved from. Used with --transactions or --extended-transactions. Format: mm/dd/yy",
+                "help": "Earliest date for transactions to be retrieved from. Used with --transactions. Format: mm/dd/yy",
             },
         ),
         (
@@ -324,7 +316,6 @@ def validate_file_extensions(options):
     if any(
         [
             options.transactions,
-            options.extended_transactions,
             options.investments,
         ]
     ):
@@ -342,28 +333,19 @@ def validate_file_extensions(options):
 
 
 def output_data(options, data, attention_msg=None):
-    # output the data
-    if options.extended_transactions:
-        if options.filename is None:
-            print(data.to_json(orient="records"))
-        elif options.filename.endswith(".csv"):
-            data.to_csv(options.filename, index=False)
-        elif options.filename.endswith(".json"):
-            data.to_json(options.filename, orient="records")
-    else:
-        if options.filename is None:
-            print(json.dumps(data, indent=2))
-        # NOTE: While this logic is here, unless validate_file_extensions
-        #       allows for other data types to export to CSV, this will
-        #       only include investment data.
-        elif options.filename.endswith(".csv"):
-            # NOTE: Currently, investment_data, which is a flat JSON, is the only
-            #       type of data that uses this section.  So, if we open this up to
-            #       other non-flat JSON data, we will need to revisit this.
-            json_normalize(data).to_csv(options.filename, index=False)
-        elif options.filename.endswith(".json"):
-            with open(options.filename, "w+") as f:
-                json.dump(data, f, indent=2)
+    if options.filename is None:
+         print(json.dumps(data, indent=2))
+    # NOTE: While this logic is here, unless validate_file_extensions
+    #       allows for other data types to export to CSV, this will
+    #       only include investment data.
+    elif options.filename.endswith(".csv"):
+    # NOTE: Currently, investment_data, which is a flat JSON, is the only
+    #       type of data that uses this section.  So, if we open this up to
+    #       other non-flat JSON data, we will need to revisit this.
+        json_normalize(data).to_csv(options.filename, index=False)
+    elif options.filename.endswith(".json"):
+        with open(options.filename, "w+") as f:
+            json.dump(data, f, indent=2)
 
     if options.attention:
         if attention_msg is None or attention_msg == "":
@@ -412,7 +394,6 @@ def main():
             options.accounts,
             options.budgets,
             options.transactions,
-            options.extended_transactions,
             options.net_worth,
             options.credit_score,
             options.credit_report,
@@ -490,9 +471,7 @@ def main():
         except Exception:
             data = None
     elif options.transactions:
-        data = mint.test_transaction_data()
-    elif options.extended_transactions:
-        data = mint.get_detailed_transactions(
+        data = mint.get_transaction_data(
             start_date=options.start_date,
             end_date=options.end_date,
             include_investment=options.include_investment,

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -334,14 +334,14 @@ def validate_file_extensions(options):
 
 def output_data(options, data, attention_msg=None):
     if options.filename is None:
-         print(json.dumps(data, indent=2))
-    # NOTE: While this logic is here, unless validate_file_extensions
-    #       allows for other data types to export to CSV, this will
-    #       only include investment data.
+        print(json.dumps(data, indent=2))
+        # NOTE: While this logic is here, unless validate_file_extensions
+        #       allows for other data types to export to CSV, this will
+        #       only include investment data.
     elif options.filename.endswith(".csv"):
-    # NOTE: Currently, investment_data, which is a flat JSON, is the only
-    #       type of data that uses this section.  So, if we open this up to
-    #       other non-flat JSON data, we will need to revisit this.
+        # NOTE: Currently, investment_data, which is a flat JSON, is the only
+        #       type of data that uses this section.  So, if we open this up to
+        #       other non-flat JSON data, we will need to revisit this.
         json_normalize(data).to_csv(options.filename, index=False)
     elif options.filename.endswith(".json"):
         with open(options.filename, "w+") as f:

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -351,7 +351,7 @@ def validate_file_extensions(options):
 
 def output_data(options, data, attention_msg=None):
     # output the data
-    if options.transactions or options.extended_transactions:
+    if options.extended_transactions:
         if options.filename is None:
             print(data.to_json(orient="records"))
         elif options.filename.endswith(".csv"):
@@ -498,11 +498,7 @@ def main():
         except Exception:
             data = None
     elif options.transactions:
-        data = mint.get_transactions(
-            start_date=options.start_date,
-            end_date=options.end_date,
-            include_investment=options.include_investment,
-        )
+        data = mint.test_transaction_data()
     elif options.extended_transactions:
         data = mint.get_detailed_transactions(
             start_date=options.start_date,

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -80,47 +80,60 @@ category_example = [
     },
 ]
 
-detailed_transactions_example = [
+detailed_transactions_example = {
+  "Transaction": [
     {
-        "date": "Oct 22",
-        "note": "",
-        "isPercent": False,
-        "fi": "",
-        "txnType": 0,
-        "numberMatchedByRule": -1,
-        "isEdited": False,
-        "isPending": False,
-        "mcategory": "Alcohol & Bars",
-        "isMatched": False,
-        "odate": "2021-10-22",
-        "isFirstDate": True,
-        "id": 1,
-        "isDuplicate": False,
-        "hasAttachments": False,
-        "isChild": False,
-        "isSpending": True,
-        "amount": 17.16,
-        "ruleCategory": "",
-        "userCategoryId": "",
-        "isTransfer": False,
-        "isAfterFiCreationTime": True,
-        "merchant": "TRIMTAB BREWING COMPANY",
-        "manualType": 0,
-        "labels": [],
-        "mmerchant": "TRIMTAB BREWING COMPANY",
-        "isCheck": False,
-        "omerchant": "TRIMTAB BREWING COMPANY",
-        "isDebit": True,
-        "category": "Alcohol & Bars",
-        "ruleMerchant": "",
-        "isLinkedToRule": False,
-        "account": "CREDIT CARD",
-        "categoryId": 708,
-        "ruleCategoryId": 0,
-    }
-]
-
-transactions_example = b'"Date","Description","Original Description","Amount","Transaction Type","Category","Account Name","Labels","Notes"\n"5/14/2020","Safeway","SAFEWAY.COM # 3031","88.09","debit","Groceries","CREDIT CARD","",""\n'
+      "type": "CashAndCreditTransaction",
+      "metaData": {
+        "lastUpdatedDate": "2022-03-25T00:11:08Z",
+        "link": [
+          {
+            "otherAttributes": {},
+            "href": "/v1/transactions/id",
+            "rel": "self"
+          }
+        ]
+      },
+      "id": "id",
+      "accountId": "accountId",
+      "accountRef": {
+        "id": "id",
+        "name": "name",
+        "type": "BankAccount",
+        "hiddenFromPlanningAndTrends": "false"
+      },
+      "date": "2022-03-24",
+      "description": "description",
+      "category": {
+        "id": "id",
+        "name": "Income",
+        "categoryType": "INCOME",
+        "parentId": "parentId",
+        "parentName": "Root"
+      },
+      "amount": 420.0,
+      "status": "MANUAL",
+      "matchState": "NOT_MATCHED",
+      "fiData": {
+        "id": "id",
+        "date": "2022-03-24",
+        "amount": 420.0,
+        "description": "description",
+        "inferredDescription": "inferredDescription",
+        "inferredCategory": {
+          "id": "id",
+          "name": "name"
+        }
+      },
+      "etag": "etag",
+      "isExpense": "false",
+      "isPending": "true",
+      "discretionaryType": "NONE",
+      "isLinkedToRule": "false",
+      "transactionReviewState": "NOT_APPLICABLE"
+    },
+  ]
+}
 
 investments_example = {
     "Investment": [
@@ -283,13 +296,6 @@ class MintApiTests(unittest.TestCase):
 
         answer = mintapi.api.parse_float("0.00%")
         self.assertEqual(answer, float(0))
-
-    @patch.object(mintapi.Mint, "get_transactions_csv")
-    def test_get_transactions(self, mocked_get_transactions):
-        mocked_get_transactions.return_value = transactions_example
-        mint = mintapi.Mint()
-        transactions_df = mint.get_transactions()
-        assert isinstance(transactions_df, pd.DataFrame)
 
     @patch.object(mintapi.Mint, "get_categories")
     def test_detailed_transactions_with_parents(self, mock_get_categories):


### PR DESCRIPTION
This PR addresses the outdated Transactions endpoint with the switch to the new Mint UI.  For v1 of this update, we are going to keep the formatting as is returned from the API, except we are popping out the metadata so that each element can be flattened for a CSV.

With this, we still support the following parameters:
* start_date
* end_date
* show_pending
* include_investment

Note that there is NO LONGER an `extended-transactions` functionality.  As we explore the new API capabilities in Mint, we'll see if there is a valid use case for that.  However, all data related to transactions is returned in the response.