### PR TITLE
🔨 - Update Accounts Endpoint

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1,7 +1,5 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
-import io
-import json
 import logging
 import os
 import random
@@ -9,9 +7,6 @@ import re
 import requests
 import time
 import warnings
-
-import xmltodict
-import pandas as pd
 
 from mintapi.signIn import sign_in, _create_web_driver_at_mint_com
 
@@ -344,7 +339,7 @@ class Mint(object):
         if include_investment:
             id = 0
         if start_date is None:
-            start_date = self.x_months_ago(2)
+            start_date = self.__x_months_ago(2)
         else:
             start_date = convert_mmddyy_to_datetime(start_date)
         if end_date is None:
@@ -381,12 +376,10 @@ class Mint(object):
             account_data = self.get_account_data()
 
         # account types in this list will be subtracted
-        invert = set(["loan", "loans", "credit"])
+        invert = set(["LoanAccount", "CreditAccount"])
         return sum(
             [
-                -a["currentBalance"]
-                if a["accountType"] in invert
-                else a["currentBalance"]
+                -a["currentBalance"] if a["type"] in invert else a["currentBalance"]
                 for a in account_data
                 if a["isActive"]
             ]

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -3,7 +3,6 @@ import logging
 import os
 import sys
 import json
-from datetime import datetime
 import getpass
 
 import keyring
@@ -267,24 +266,6 @@ def parse_arguments(args):
         cmdline.add_argument(*argument_commands, **argument_options)
 
     return cmdline.parse_args(args)
-
-
-def make_accounts_presentable(accounts, presentable_format="EXCEL"):
-    formatter = {
-        "DATE": "%Y-%m-%d",
-        "ISO8601": "%Y-%m-%dT%H:%M:%SZ",
-        "EXCEL": "%Y-%m-%d %H:%M:%S",
-    }[presentable_format]
-
-    for account in accounts:
-        for k, v in account.items():
-            if isinstance(v, datetime):
-                account[k] = v.strftime(formatter)
-    return accounts
-
-
-def print_accounts(accounts):
-    print(json.dumps(make_accounts_presentable(accounts), indent=2))
 
 
 def handle_password(type, prompt, email, password, use_keyring=False):

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -114,7 +114,7 @@ def parse_arguments(args):
             {
                 "nargs": "?",
                 "default": None,
-                "help": "Latest date for transactions to be retrieved from. Used with --transactions or --extended-transactions. Format: mm/dd/yy",
+                "help": "Latest date for transactions to be retrieved from. Used with --transactions. Format: mm/dd/yy",
             },
         ),
         (
@@ -151,14 +151,6 @@ def parse_arguments(args):
             },
         ),
         (
-            ("--extended-transactions",),
-            {
-                "action": "store_true",
-                "default": False,
-                "help": "Retrieve transactions with extra information and arguments",
-            },
-        ),
-        (
             ("--filename", "-f"),
             {
                 "help": "write results to file. can be {csv,json} format. default is to write to stdout."
@@ -192,7 +184,7 @@ def parse_arguments(args):
             {
                 "action": "store_true",
                 "default": False,
-                "help": "Used with --extended-transactions",
+                "help": "Used with --transactions",
             },
         ),
         (
@@ -245,15 +237,7 @@ def parse_arguments(args):
             {
                 "action": "store_false",
                 "default": True,
-                "help": "Exclude pending transactions from being retrieved. Used with --extended-transactions",
-            },
-        ),
-        (
-            ("--skip-duplicates",),
-            {
-                "action": "store_true",
-                "default": False,
-                "help": "Used with --extended-transactions",
+                "help": "Exclude pending transactions from being retrieved. Used with --transactions",
             },
         ),
         (
@@ -261,7 +245,7 @@ def parse_arguments(args):
             {
                 "nargs": "?",
                 "default": None,
-                "help": "Earliest date for transactions to be retrieved from. Used with --transactions or --extended-transactions. Format: mm/dd/yy",
+                "help": "Earliest date for transactions to be retrieved from. Used with --transactions. Format: mm/dd/yy",
             },
         ),
         (
@@ -332,7 +316,6 @@ def validate_file_extensions(options):
     if any(
         [
             options.transactions,
-            options.extended_transactions,
             options.investments,
         ]
     ):
@@ -350,28 +333,19 @@ def validate_file_extensions(options):
 
 
 def output_data(options, data, attention_msg=None):
-    # output the data
-    if options.transactions or options.extended_transactions:
-        if options.filename is None:
-            print(data.to_json(orient="records"))
-        elif options.filename.endswith(".csv"):
-            data.to_csv(options.filename, index=False)
-        elif options.filename.endswith(".json"):
-            data.to_json(options.filename, orient="records")
-    else:
-        if options.filename is None:
-            print(json.dumps(data, indent=2))
+    if options.filename is None:
+        print(json.dumps(data, indent=2))
         # NOTE: While this logic is here, unless validate_file_extensions
         #       allows for other data types to export to CSV, this will
         #       only include investment data.
-        elif options.filename.endswith(".csv"):
-            # NOTE: Currently, investment_data, which is a flat JSON, is the only
-            #       type of data that uses this section.  So, if we open this up to
-            #       other non-flat JSON data, we will need to revisit this.
-            json_normalize(data).to_csv(options.filename, index=False)
-        elif options.filename.endswith(".json"):
-            with open(options.filename, "w+") as f:
-                json.dump(data, f, indent=2)
+    elif options.filename.endswith(".csv"):
+        # NOTE: Currently, investment_data, which is a flat JSON, is the only
+        #       type of data that uses this section.  So, if we open this up to
+        #       other non-flat JSON data, we will need to revisit this.
+        json_normalize(data).to_csv(options.filename, index=False)
+    elif options.filename.endswith(".json"):
+        with open(options.filename, "w+") as f:
+            json.dump(data, f, indent=2)
 
     if options.attention:
         if attention_msg is None or attention_msg == "":
@@ -420,7 +394,6 @@ def main():
             options.accounts,
             options.budgets,
             options.transactions,
-            options.extended_transactions,
             options.net_worth,
             options.credit_score,
             options.credit_report,
@@ -468,9 +441,7 @@ def main():
     data = None
     if options.accounts and options.budgets:
         try:
-            accounts = make_accounts_presentable(
-                mint.get_accounts(get_detail=options.accounts_ext)
-            )
+            accounts = mint.get_account_data(get_detail=options.accounts_ext)
         except Exception:
             accounts = None
 
@@ -492,24 +463,15 @@ def main():
             data = None
     elif options.accounts:
         try:
-            data = make_accounts_presentable(
-                mint.get_accounts(get_detail=options.accounts_ext)
-            )
+            data = mint.get_account_data(get_detail=False)
         except Exception:
             data = None
     elif options.transactions:
-        data = mint.get_transactions(
-            start_date=options.start_date,
-            end_date=options.end_date,
-            include_investment=options.include_investment,
-        )
-    elif options.extended_transactions:
-        data = mint.get_detailed_transactions(
+        data = mint.get_transaction_data(
             start_date=options.start_date,
             end_date=options.end_date,
             include_investment=options.include_investment,
             remove_pending=options.show_pending,
-            skip_duplicates=options.skip_duplicates,
         )
     elif options.categories:
         data = mint.get_categories()

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -14,15 +14,62 @@ import tempfile
 from unittest.mock import patch, DEFAULT
 
 
-accounts_example = [
-    {
-        "accountName": "Chase Checking",
-        "lastUpdated": 1401201492000,
-        "lastUpdatedInString": "25 minutes",
-        "accountType": "bank",
-        "currentBalance": 100.12,
-    }
-]
+accounts_example = {
+    "Account": [
+        {
+            "type": "CreditAccount",
+            "userCardType": "UNKNOWN",
+            "creditAccountType": "CREDIT_CARD",
+            "creditLimit": 2222.0,
+            "availableCredit": 1111.0,
+            "interestRate": 0.444,
+            "minPayment": 111.0,
+            "absoluteMinPayment": 111.0,
+            "statementMinPayment": 22.0,
+            "statementDueDate": "2022-04-19T07:00:00Z",
+            "statementDueAmount": 0.0,
+            "metaData": {
+                "createdDate": "2017-01-05T17:12:15Z",
+                "lastUpdatedDate": "2022-03-27T16:46:41Z",
+                "link": [
+                    {
+                        "otherAttributes": {},
+                        "href": "/v1/accounts/id",
+                        "rel": "self",
+                    }
+                ],
+            },
+            "id": "id",
+            "name": "name",
+            "value": -555.55,
+            "isVisible": True,
+            "isDeleted": False,
+            "planningTrendsVisible": True,
+            "accountStatus": "ACTIVE",
+            "systemStatus": "ACTIVE",
+            "currency": "USD",
+            "fiLoginId": "fiLoginId",
+            "fiLoginStatus": "OK",
+            "currentBalance": 555.55,
+            "cpId": "cpId",
+            "cpAccountName": "cpAccountName",
+            "cpAccountNumberLast4": "cpAccountNumberLast4",
+            "hostAccount": False,
+            "fiName": "fiName",
+            "accountTypeInt": 0,
+            "isAccountClosedByMint": False,
+            "isAccountNotFound": False,
+            "isActive": True,
+            "isClosed": False,
+            "isError": False,
+            "isHiddenFromPlanningTrends": True,
+            "isTerminal": True,
+            "credentialSetId": "credentialSetId",
+            "ccAggrStatus": "0",
+        }
+    ]
+}
+
 
 category_example = [
     {
@@ -204,27 +251,6 @@ class TestMock:
 
 
 class MintApiTests(unittest.TestCase):
-    @patch.object(mintapi.api, "sign_in")
-    @patch.object(mintapi.api, "_create_web_driver_at_mint_com")
-    def test_accounts(self, mock_driver, mock_sign_in):
-        mock_driver.return_value = TestMock()
-        mock_sign_in.return_value = ("test", "token")
-        accounts = mintapi.get_accounts("foo", "bar")
-
-        self.assertFalse("lastUpdatedInDate" in accounts)
-        self.assertNotEqual(accounts, accounts_example)
-
-        accounts_annotated = copy.deepcopy(accounts_example)
-        for account in accounts_annotated:
-            account["lastUpdatedInDate"] = datetime.datetime.fromtimestamp(
-                account["lastUpdated"] / 1000
-            )
-        self.assertEqual(accounts, accounts_annotated)
-
-        # ensure everything is json serializable as this is the command-line
-        # behavior.
-        mintapi.cli.print_accounts(accounts)
-
     def test_chrome_driver_links(self):
         latest_version = mintapi.signIn.get_latest_chrome_driver_version()
         for platform in mintapi.signIn.CHROME_ZIP_TYPES:
@@ -319,6 +345,14 @@ class MintApiTests(unittest.TestCase):
         mock_driver.return_value = (TestMock(), "test")
         url = mintapi.Mint.build_bundledServiceController_url(mock_driver)
         self.assertTrue(mintapi.api.MINT_ROOT_URL in url)
+
+    @patch.object(mintapi.Mint, "_Mint__call_accounts_endpoint")
+    def test_get_investment_data_new(self, mock_call_accounts_endpoint):
+        mock_call_accounts_endpoint.return_value = accounts_example
+        account_data = mintapi.Mint().get_account_data()[0]
+        self.assertFalse("metaData" in account_data)
+        self.assertTrue("createdDate" in account_data)
+        self.assertTrue("lastUpdatedDate" in account_data)
 
     @patch.object(mintapi.Mint, "_Mint__call_investments_endpoint")
     def test_get_investment_data_new(self, mock_call_investments_endpoint):


### PR DESCRIPTION
This PR addresses the outdated Accounts endpoint with the switch to the new Mint UI.  For v1 of this update, we are going to keep the formatting as is returned from the API, except we are popping out the metadata so that each element can be flattened for a CSV.

Note that there is NO LONGER an `extended-accounts` functionality.  This functionality was a nasty workaround that involved scrapping div elements off the screen.  Considering that the majority of the data is already in the response and that the UI changed, Mintapi will no longer attempt to pull data in this fashion.