### PR TITLE
update version to 1.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.65
+---
+- NOTE: This is intended to be the final release of 1.x.
+  Further work will go towards a 2.0 release which will only support the
+  new Mint UI and endpoints.
+- fix for selenium dependency version (#412, #413, #416)
+
 1.64
 ---
 - Resolves Selenium Requests Error #408

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     description="a screen-scraping API for Mint.com",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="1.64",
+    version="1.65",
     packages=["mintapi"],
     license="The MIT License",
     author="Michael Rooney",


### PR DESCRIPTION
This is intended for merge into `release/1.65` which can then be released and merged back to `main` :) I welcome any improvements to wording, etc. After this, I'll do the pending 2.0 CHANGELOG.