### PR TITLE
[FEATURE] - Add Data Format Option to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+2.0 (Pending)
+---
+
+- Add Data Format Option to CLI: `--format` (#432)
+- Update Accounts Endpoint to meet new Mint requirements (#430) 
+- Update Transactions Endpoint to meet new Mint requirements (#429) 
+- Update Budgets Endpoint to meet new Mint requirements (#425)
+- Support removed for hiding duplicate transactions (#427)
+- Fetch the correct API Key to use with Mint API Requests (#420, #423)
+- Removed `get_token` functionality, which is incompatible with the new Mint UI (#421)
+- Update the name of the Account Refresh Class (#415)
+- Update the overview page url (#414) 
+
+BREAKING CHANGES:
+- Because of the new Mint UI and the switchover to different API Endpoints, the data structure associated with each function may be different.  Please verify that the data you are expecting against the new output of each endpoint.
+- To help support the new CLI option for data format (`--format`), we have eliminated the need to specify a file extension in `--filename`.  Be aware that if you do not specify `--format=csv`, then the extension\format will be `json`, which means that any filename you specify will include the extension of `.json`.
+
+
 1.64
 ---
 - Resolves Selenium Requests Error #408

--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                    [--exclude-inquiries] [--exclude-accounts] [--exclude-utilization]
                    [--start-date [START_DATE]] [--end-date [END_DATE]]
                    [--include-investment] [--show-pending]
-                   [--filename FILENAME] [--keyring] [--headless] [--attention]
+                   [--format] [--filename FILENAME] [--keyring] [--headless]
                    [--mfa-method {sms,email,soft-token}]
-                   [--categories]
+                   [--categories] [--attention]
                    email [password]
 
     positional arguments:
@@ -225,8 +225,8 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
       --show-pending        Exclude pending transactions from being retrieved.
                             Used with --transactions
       --filename FILENAME, -f FILENAME
-                            write results to file. can be {csv,json} format.
-                            default is to write to stdout.
+                            write results to file. If no file is specified, then data is written to stdout.  Do not specify the file extension as it is determined based on the selection of `--format`.
+      --format              Determines the output format of the data, either `csv` or         `json`.  The default value is `json`.  If no `filename` is specified, then this determines the `stdout` format.  Otherwise, if a `filename` is specified, then this determines the file extension.
       --keyring             Use OS keyring for storing password information
       --headless            Whether to execute chromedriver with no visible
                             window.

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -15,6 +15,9 @@ from pandas import json_normalize
 
 logger = logging.getLogger("mintapi")
 
+JSON_FORMAT = "json"
+CSV_FORMAT = "csv"
+
 
 def parse_arguments(args):
     ARGUMENTS = [
@@ -154,6 +157,14 @@ def parse_arguments(args):
             ("--filename", "-f"),
             {
                 "help": "write results to file. can be {csv,json} format. default is to write to stdout."
+            },
+        ),
+        (
+            ("--format",),
+            {
+                "choices": [JSON_FORMAT, CSV_FORMAT],
+                "default": JSON_FORMAT,
+                "help": "The format used to return data.",
             },
         ),
         (
@@ -312,39 +323,31 @@ def handle_password(type, prompt, email, password, use_keyring=False):
     return password
 
 
-def validate_file_extensions(options):
-    if any(
-        [
-            options.transactions,
-            options.investments,
-        ]
-    ):
-        if not (
-            options.filename is None
-            or options.filename.endswith(".csv")
-            or options.filename.endswith(".json")
-        ):
-            raise ValueError(
-                "File extension must be either .csv or .json for transaction data"
-            )
+def format_filename(options):
+    if options.filename is None:
+        filename = None
     else:
-        if not (options.filename is None or options.filename.endswith(".json")):
-            raise ValueError("File extension must be .json for non-transaction data")
+        filename = "{}.{}".format(options.filename, options.format)
+    return filename
 
 
 def output_data(options, data, attention_msg=None):
-    if options.filename is None:
-        print(json.dumps(data, indent=2))
+    filename = format_filename(options)
+    if filename is None:
+        if options.format == CSV_FORMAT:
+            print(json_normalize(data).to_csv(index=False))
+        else:
+            print(json.dumps(data, indent=2))
         # NOTE: While this logic is here, unless validate_file_extensions
         #       allows for other data types to export to CSV, this will
         #       only include investment data.
-    elif options.filename.endswith(".csv"):
+    elif options.format == CSV_FORMAT:
         # NOTE: Currently, investment_data, which is a flat JSON, is the only
         #       type of data that uses this section.  So, if we open this up to
         #       other non-flat JSON data, we will need to revisit this.
-        json_normalize(data).to_csv(options.filename, index=False)
-    elif options.filename.endswith(".json"):
-        with open(options.filename, "w+") as f:
+        json_normalize(data).to_csv(filename, index=False)
+    elif options.format == JSON_FORMAT:
+        with open(filename, "w+") as f:
             json.dump(data, f, indent=2)
 
     if options.attention:
@@ -366,8 +369,6 @@ def main():
     imap_account = options.imap_account
     imap_password = options.imap_password
     mfa_method = options.mfa_method
-
-    validate_file_extensions(options)
 
     if not email:
         # If the user did not provide an e-mail, prompt for it

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -337,34 +337,38 @@ class MintApiTests(unittest.TestCase):
         self.assertFalse("metaData" in budgets)
         self.assertTrue("lastUpdatedDate" in budgets)
 
-    def test_validate_file_extensions(self):
+    def test_format_filename(self):
         config_file = write_transactions_file()
-        config_file.write("filename=/tmp/transactions.txt")
         arguments = parse_arguments_file(config_file)
-        self.assertRaises(ValueError, mintapi.cli.validate_file_extensions, arguments)
-        config_file = write_transactions_file()
-        config_file.write("filename=/tmp/transactions.csv")
-        arguments = parse_arguments_file(config_file)
-        self.assertEqual(mintapi.cli.validate_file_extensions(arguments), None)
+        filename = mintapi.cli.format_filename(arguments)
+        self.assertEqual(filename, "transactions.csv")
+
         config_file = write_accounts_file()
-        config_file.write("filename=/tmp/accounts.csv")
         arguments = parse_arguments_file(config_file)
-        self.assertRaises(ValueError, mintapi.cli.validate_file_extensions, arguments)
-        config_file = write_accounts_file()
-        config_file.write("filename=/tmp/accounts.json")
+        filename = mintapi.cli.format_filename(arguments)
+        self.assertEqual(filename, "accounts.json")
+
+        config_file = write_investments_file()
         arguments = parse_arguments_file(config_file)
-        self.assertEqual(mintapi.cli.validate_file_extensions(arguments), None)
+        filename = mintapi.cli.format_filename(arguments)
+        self.assertEqual(filename, None)
 
 
 def write_transactions_file():
     config_file = tempfile.NamedTemporaryFile(mode="wt")
-    config_file.write("transactions\n")
+    config_file.write("transactions\nformat=csv\nfilename=transactions")
     return config_file
 
 
 def write_accounts_file():
     config_file = tempfile.NamedTemporaryFile(mode="wt")
-    config_file.write("accounts\n")
+    config_file.write("accounts\nformat=json\nfilename=accounts")
+    return config_file
+
+
+def write_investments_file():
+    config_file = tempfile.NamedTemporaryFile(mode="wt")
+    config_file.write("investments")
     return config_file
 
 


### PR DESCRIPTION
Currently, the format of the output is determined based on the file extension specified.  In addition, the only available format when printing to `stdout` is json.  This PR makes a couple of enhancements:

* A new CLI option is added: `--format`.  Its valid values are `csv` and `json`, with `json` as the default answer.
* The filename no longer includes the extension.  It will be determined based on the value of `--format`.
* If no filename is specified, then the format in `stdout` is determined based on `--format`.

This PR addresses #89 . 