### PR TITLE
🔨 - Dynamically use Endpoints

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -18,48 +18,43 @@ CATEGORY_KEY = "Category"
 INVESTMENT_KEY = "Investment"
 TRANSACTION_KEY = "Transaction"
 
-ENDPOINTS = [
-    {
-        "key": ACCOUNT_KEY,
+ENDPOINTS = {
+    ACCOUNT_KEY: {
         "apiVersion": "pfm/v1",
         "endpoint": "accounts",
         "beginningDate": None,
         "endingDate": None,
         "includeCreatedDate": True,
     },
-    {
-        "key": BUDGET_KEY,
+    BUDGET_KEY: {
         "apiVersion": "pfm/v1",
         "endpoint": "budgets",
         "beginningDate": "startDate",
         "endingDate": "endDate",
         "includeCreatedDate": True,
     },
-    {
-        "key": CATEGORY_KEY,
+    CATEGORY_KEY: {
         "apiVersion": "pfm/v1",
         "endpoint": "categories",
         "beginningDate": None,
         "endingDate": None,
         "includeCreatedDate": False,
     },
-    {
-        "key": INVESTMENT_KEY,
+    INVESTMENT_KEY: {
         "apiVersion": "pfm/v1",
         "endpoint": "investments",
         "beginningDate": None,
         "endingDate": None,
         "includeCreatedDate": False,
     },
-    {
-        "key": TRANSACTION_KEY,
+    TRANSACTION_KEY: {
         "apiVersion": "pfm/v1",
         "endpoint": "transactions",
         "beginningDate": "fromDate",
         "endingDate": "toDate",
         "includeCreatedDate": False,
     },
-]
+}
 
 
 def convert_mmddyy_to_datetime(date):
@@ -226,9 +221,8 @@ class Mint(object):
     def get_data(self, name, id=None, start_date=None, end_date=None):
         endpoint = self.__find_endpoint(name)
         data = self.__call_mint_endpoint(endpoint, id, start_date, end_date)
-        key = endpoint["key"]
-        if key in data.keys():
-            for i in data[key]:
+        if name in data.keys():
+            for i in data[name]:
                 if endpoint["includeCreatedDate"]:
                     i["createdDate"] = i["metaData"]["createdDate"]
                 i["lastUpdatedDate"] = i["metaData"]["lastUpdatedDate"]
@@ -236,10 +230,10 @@ class Mint(object):
         else:
             raise MintException(
                 "Data from the {} endpoint did not containt the expected {} key.".format(
-                    endpoint["endpoint"], key
+                    endpoint["endpoint"], name
                 )
             )
-        return data[key]
+        return data[name]
 
     def get_account_data(self):
         return self.get_data(ACCOUNT_KEY)
@@ -428,11 +422,7 @@ class Mint(object):
         return utilization
 
     def __find_endpoint(self, name):
-        filtered = filter(
-            lambda endpoint: endpoint["key"] == name,
-            ENDPOINTS,
-        )
-        return list(filtered)[0]
+        return ENDPOINTS[name]
 
     def __call_mint_endpoint(self, endpoint, id=None, start_date=None, end_date=None):
         url = "{}/{}/{}?".format(

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -10,8 +10,56 @@ import warnings
 
 from mintapi.signIn import sign_in, _create_web_driver_at_mint_com
 
-
 logger = logging.getLogger("mintapi")
+
+ACCOUNT_KEY = "Account"
+BUDGET_KEY = "Budget"
+CATEGORY_KEY = "Category"
+INVESTMENT_KEY = "Investment"
+TRANSACTION_KEY = "Transaction"
+
+ENDPOINTS = [
+    {
+        "key": ACCOUNT_KEY,
+        "apiVersion": "pfm/v1",
+        "endpoint": "accounts",
+        "beginningDate": None,
+        "endingDate": None,
+        "includeCreatedDate": True,
+    },
+    {
+        "key": BUDGET_KEY,
+        "apiVersion": "pfm/v1",
+        "endpoint": "budgets",
+        "beginningDate": "startDate",
+        "endingDate": "endDate",
+        "includeCreatedDate": True,
+    },
+    {
+        "key": CATEGORY_KEY,
+        "apiVersion": "pfm/v1",
+        "endpoint": "categories",
+        "beginningDate": None,
+        "endingDate": None,
+        "includeCreatedDate": False,
+    },
+    {
+        "key": INVESTMENT_KEY,
+        "apiVersion": "pfm/v1",
+        "endpoint": "investments",
+        "beginningDate": None,
+        "endingDate": None,
+        "includeCreatedDate": False,
+    },
+    {
+        "key": TRANSACTION_KEY,
+        "apiVersion": "pfm/v1",
+        "endpoint": "transactions",
+        "beginningDate": "fromDate",
+        "endingDate": "toDate",
+        "includeCreatedDate": False,
+    },
+]
 
 
 def json_date_to_datetime(dateraw):
@@ -264,32 +312,40 @@ class Mint(object):
         else:
             logger.error("FAIL2")
 
-    def get_investment_data(self):
-        investments = self.__call_investments_endpoint()
-        if "Investment" in investments.keys():
-            for i in investments["Investment"]:
+    def get_data(self, name, id=None, start_date=None, end_date=None):
+        endpoint = self.__find_endpoint(name)
+        data = self.__call_mint_endpoint(endpoint, id, start_date, end_date)
+        key = endpoint["key"]
+        if key in data.keys():
+            for i in data[key]:
+                if endpoint["includeCreatedDate"]:
+                    i["createdDate"] = i["metaData"]["createdDate"]
                 i["lastUpdatedDate"] = i["metaData"]["lastUpdatedDate"]
                 i.pop("metaData", None)
         else:
-            raise MintException("Cannot find investment data")
-        return investments["Investment"]
+            raise MintException(
+                "Data from the {} endpoint did not containt the expected {} key.".format(
+                    endpoint["endpoint"], key
+                )
+            )
+        return data[key]
 
     def get_account_data(self):
-        accounts = self.__call_accounts_endpoint()
-        if "Account" in accounts.keys():
-            for i in accounts["Account"]:
-                i["createdDate"] = i["metaData"]["createdDate"]
-                i["lastUpdatedDate"] = i["metaData"]["lastUpdatedDate"]
-                i.pop("metaData", None)
-        else:
-            raise MintException("Cannot find account data")
-        return accounts["Account"]
+        return self.get_data(ACCOUNT_KEY)
 
-    def __call_accounts_endpoint(self):
-        return self.get(
-            "{}/pfm/v1/accounts".format(MINT_ROOT_URL),
-            headers=self._get_api_key_header(),
-        ).json()
+    def get_categories(self):
+        return self.get_data(CATEGORY_KEY)
+
+    def get_budgets(self):
+        return self.get_data(
+            BUDGET_KEY,
+            None,
+            start_date=self.__x_months_ago(11),
+            end_date=self.__first_of_this_month(),
+        )
+
+    def get_investment_data(self):
+        return self.get_data(INVESTMENT_KEY)
 
     def get_transaction_data(
         self,
@@ -310,66 +366,24 @@ class Mint(object):
         remove_pending to False
         """
 
-        result = self.__call_transactions_endpoint(
-            include_investment, start_date, end_date, id
-        )
-        if "Transaction" in result.keys():
+        try:
+            if include_investment:
+                id = 0
+            data = self.get_data(
+                TRANSACTION_KEY,
+                id,
+                convert_mmddyy_to_datetime(start_date),
+                convert_mmddyy_to_datetime(end_date),
+            )
             if remove_pending:
                 filtered = filter(
                     lambda transaction: transaction["isPending"] == False,
-                    result["Transaction"],
+                    data,
                 )
-                transactions = list(filtered)
-            else:
-                transactions = result["Transaction"]
-            for i in transactions:
-                i["lastUpdatedDate"] = i["metaData"]["lastUpdatedDate"]
-                i.pop("metaData", None)
-
-        else:
-            raise MintException("Cannot find transaction data")
-        return transactions
-
-    def __call_transactions_endpoint(
-        self, include_investment=False, start_date=None, end_date=None, id=0
-    ):
-        # Specifying accountId=0 causes Mint to return investment
-        # transactions as well.  Otherwise they are skipped by
-        # default.
-        if include_investment:
-            id = 0
-        if start_date is None:
-            start_date = self.__x_months_ago(2)
-        else:
-            start_date = convert_mmddyy_to_datetime(start_date)
-        if end_date is None:
-            end_date = date.today()
-        else:
-            end_date = convert_mmddyy_to_datetime(end_date)
-        return self.get(
-            "{}/pfm/v1/transactions?id={}&fromDate={}&toDate={}".format(
-                MINT_ROOT_URL, id, start_date, end_date
-            ),
-            headers=self._get_api_key_header(),
-        ).json()
-
-    def __call_investments_endpoint(self):
-        return self.get(
-            "{}/pfm/v1/investments".format(MINT_ROOT_URL),
-            headers=self._get_api_key_header(),
-        ).json()
-
-    def get_categories(self):
-        return self.get(
-            "{}/pfm/v1/categories".format(MINT_ROOT_URL),
-            headers=self._get_api_key_header(),
-        ).json()["Category"]
-
-    def __call_accounts_endpoint(self):
-        return self.get(
-            "{}/pfm/v1/accounts".format(MINT_ROOT_URL),
-            headers=self._get_api_key_header(),
-        ).json()
+                data = list(filtered)
+        except Exception:
+            raise Exception
+        return data
 
     def get_net_worth(self, account_data=None):
         if account_data is None:
@@ -384,24 +398,6 @@ class Mint(object):
                 if a["isActive"]
             ]
         )
-
-    def get_budgets(self):
-        budgets = self.__call_budgets_endpoint()
-        if "Budget" in budgets.keys():
-            for i in budgets["Budget"]:
-                i["lastUpdatedDate"] = i["metaData"]["lastUpdatedDate"]
-                i.pop("metaData", None)
-        else:
-            raise MintException("Cannot find budget data")
-        return budgets["Budget"]
-
-    def __call_budgets_endpoint(self):
-        return self.get(
-            "{}/pfm/v1/budgets?startDate={}&endDate={}".format(
-                MINT_ROOT_URL, self.__x_months_ago(11), self.__first_of_this_month()
-            ),
-            headers=self._get_api_key_header(),
-        ).json()
 
     def initiate_account_refresh(self):
         self.make_post_request(url="{}/refreshFILogins.xevent".format(MINT_ROOT_URL))
@@ -519,6 +515,29 @@ class Mint(object):
                     }
                 )
         return utilization
+
+    def __find_endpoint(self, name):
+        filtered = filter(
+            lambda endpoint: endpoint["key"] == name,
+            ENDPOINTS,
+        )
+        return list(filtered)[0]
+
+    def __call_mint_endpoint(self, endpoint, id=None, start_date=None, end_date=None):
+        url = "{}/{}/{}?".format(
+            MINT_ROOT_URL, endpoint["apiVersion"], endpoint["endpoint"]
+        )
+        if endpoint["beginningDate"] is not None and start_date is not None:
+            url = url + "{}={}&".format(endpoint["beginningDate"], start_date)
+        if endpoint["endingDate"] is not None and end_date is not None:
+            url = url + "{}={}&".format(endpoint["endingDate"], end_date)
+        if id is not None:
+            url = url + "id={}&".format(id)
+        response = self.get(
+            url,
+            headers=self._get_api_key_header(),
+        )
+        return response.json()
 
     def __first_of_this_month(self):
         return date.today().replace(day=1)

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -340,7 +340,7 @@ class MintApiTests(unittest.TestCase):
         url = mintapi.Mint.build_bundledServiceController_url(mock_driver)
         self.assertTrue(mintapi.api.MINT_ROOT_URL in url)
 
-    @patch.object(mintapi.Mint, "_Mint__call_accounts_endpoint")
+    @patch.object(mintapi.Mint, "_Mint__call_mint_endpoint")
     def test_get_investment_data_new(self, mock_call_accounts_endpoint):
         mock_call_accounts_endpoint.return_value = accounts_example
         account_data = mintapi.Mint().get_account_data()[0]
@@ -348,27 +348,30 @@ class MintApiTests(unittest.TestCase):
         self.assertTrue("createdDate" in account_data)
         self.assertTrue("lastUpdatedDate" in account_data)
 
-    @patch.object(mintapi.Mint, "_Mint__call_transactions_endpoint")
+    @patch.object(mintapi.Mint, "_Mint__call_mint_endpoint")
     def test_get_transaction_data(self, mock_call_transactions_endpoint):
         mock_call_transactions_endpoint.return_value = transactions_example
         transaction_data = mintapi.Mint().get_transaction_data()[0]
         self.assertFalse("metaData" in transaction_data)
+        self.assertFalse("createdDate" in transaction_data)
         self.assertTrue("lastUpdatedDate" in transaction_data)
         self.assertTrue("parentId" in transaction_data["category"])
         self.assertTrue("parentName" in transaction_data["category"])
 
-    @patch.object(mintapi.Mint, "_Mint__call_investments_endpoint")
+    @patch.object(mintapi.Mint, "_Mint__call_mint_endpoint")
     def test_get_investment_data_new(self, mock_call_investments_endpoint):
         mock_call_investments_endpoint.return_value = investments_example
         investment_data = mintapi.Mint().get_investment_data()[0]
         self.assertFalse("metaData" in investment_data)
+        self.assertFalse("createdDate" in investment_data)
         self.assertTrue("lastUpdatedDate" in investment_data)
 
-    @patch.object(mintapi.Mint, "_Mint__call_budgets_endpoint")
+    @patch.object(mintapi.Mint, "_Mint__call_mint_endpoint")
     def test_get_budgets(self, mock_call_budgets_endpoint):
         mock_call_budgets_endpoint.return_value = budgets_example
         budgets = mintapi.Mint().get_budgets()[0]
         self.assertFalse("metaData" in budgets)
+        self.assertTrue("createdDate" in budgets)
         self.assertTrue("lastUpdatedDate" in budgets)
 
     def test_validate_file_extensions(self):


### PR DESCRIPTION
This PR creates general methods for getting data from an endpoint using settings configured in a constant dictionary.  The settings include the following settings:

* apiVersion
* endpoint
* beginningDate
* endingDate
* includeCreatedDate

`beginningDate` is used to specify a potential beginning date query parameter in the API request.  If there is none, we set this to `None`.
`endingDate` is used to specify a potential ending date query parameter in the API request.  If there is none, we set this to `None`.
`includeCreatedDate` is used to toggle whether the metadata object of the response includes `createdDate`.