### PR TITLE
[FEATURE] - Add parameter to control limit of records

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                    [--transactions] [--credit-score] [--credit-report]
                    [--exclude-inquiries] [--exclude-accounts] [--exclude-utilization]
                    [--start-date [START_DATE]] [--end-date [END_DATE]]
-                   [--include-investment] [--show-pending]
+                   [--limit] [--include-investment] [--show-pending]
                    [--format] [--filename FILENAME] [--keyring] [--headless]
                    [--mfa-method {sms,email,soft-token}]
                    [--categories] [--attention]
@@ -222,6 +222,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                             Used with --transactions. Format: mm/dd/yy
       --investments         Retrieve data related to your investments, whether they be retirement or         personal stock purchases
       --include-investment  Used with --transactions
+      --limit               Number of records to include from the API.  Default is 5000.
       --show-pending        Retrieve pending transactions.
                             Used with --transactions
       --filename FILENAME, -f FILENAME

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -218,9 +218,9 @@ class Mint(object):
             headers=self._get_api_key_header(),
         ).json()["bills"]
 
-    def get_data(self, name, id=None, start_date=None, end_date=None):
+    def get_data(self, name, limit, id=None, start_date=None, end_date=None):
         endpoint = self.__find_endpoint(name)
-        data = self.__call_mint_endpoint(endpoint, id, start_date, end_date)
+        data = self.__call_mint_endpoint(endpoint, limit, id, start_date, end_date)
         if name in data.keys():
             for i in data[name]:
                 if endpoint["includeCreatedDate"]:
@@ -235,25 +235,42 @@ class Mint(object):
             )
         return data[name]
 
-    def get_account_data(self):
-        return self.get_data(ACCOUNT_KEY)
+    def get_account_data(
+        self,
+        limit=5000,
+    ):
+        return self.get_data(ACCOUNT_KEY, limit)
 
-    def get_categories(self):
-        return self.get_data(CATEGORY_KEY)
+    def get_categories(
+        self,
+        limit=5000,
+    ):
+        return self.get_data(CATEGORY_KEY, limit)
 
-    def get_budgets(self):
+    def get_budgets(
+        self,
+        limit=5000,
+    ):
         return self.get_data(
             BUDGET_KEY,
+            limit,
             None,
             start_date=self.__x_months_ago(11),
             end_date=self.__first_of_this_month(),
         )
 
-    def get_investment_data(self):
-        return self.get_data(INVESTMENT_KEY)
+    def get_investment_data(
+        self,
+        limit=5000,
+    ):
+        return self.get_data(
+            INVESTMENT_KEY,
+            limit,
+        )
 
     def get_transaction_data(
         self,
+        limit=5000,
         include_investment=False,
         start_date=None,
         end_date=None,
@@ -276,6 +293,7 @@ class Mint(object):
                 id = 0
             data = self.get_data(
                 TRANSACTION_KEY,
+                limit,
                 id,
                 convert_mmddyy_to_datetime(start_date),
                 convert_mmddyy_to_datetime(end_date),
@@ -424,9 +442,11 @@ class Mint(object):
     def __find_endpoint(self, name):
         return ENDPOINTS[name]
 
-    def __call_mint_endpoint(self, endpoint, id=None, start_date=None, end_date=None):
-        url = "{}/{}/{}?".format(
-            MINT_ROOT_URL, endpoint["apiVersion"], endpoint["endpoint"]
+    def __call_mint_endpoint(
+        self, endpoint, limit, id=None, start_date=None, end_date=None
+    ):
+        url = "{}/{}/{}?limit={}&".format(
+            MINT_ROOT_URL, endpoint["apiVersion"], endpoint["endpoint"], limit
         )
         if endpoint["beginningDate"] is not None and start_date is not None:
             url = url + "{}={}&".format(endpoint["beginningDate"], start_date)

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -196,6 +196,14 @@ def parse_arguments(args):
             },
         ),
         (
+            ("--limit",),
+            {
+                "type": int,
+                "default": 5000,
+                "help": "Number of records to include from the API.  Default is 5000.",
+            },
+        ),
+        (
             ("--mfa-method",),
             {
                 "choices": ["sms", "email", "soft-token"],
@@ -411,42 +419,47 @@ def main():
     data = None
     if options.accounts and options.budgets:
         try:
-            data = mint.get_account_data()
+            data = mint.get_account_data(limit=options.limit)
         except Exception:
             accounts = None
 
         try:
-            budgets = mint.get_budgets()
+            budgets = mint.get_budgets(limit=options.limit)
         except Exception:
             budgets = None
 
         data = {"accounts": accounts, "budgets": budgets}
     elif options.budgets:
         try:
-            data = mint.get_budgets()
+            data = mint.get_budgets(limit=options.limit)
         except Exception:
             data = None
     elif options.budget_hist:
         try:
-            data = mint.get_budgets(hist=12)
+            data = mint.get_budgets(limit=options.limit, hist=12)
         except Exception:
             data = None
     elif options.accounts:
         try:
-            data = mint.get_account_data()
+            data = mint.get_account_data(limit=options.limit)
         except Exception:
             data = None
     elif options.transactions:
         data = mint.get_transaction_data(
+            limit=options.limit,
             start_date=options.start_date,
             end_date=options.end_date,
             include_investment=options.include_investment,
             remove_pending=options.show_pending,
         )
     elif options.categories:
-        data = mint.get_categories()
+        data = mint.get_categories(
+            limit=options.limit,
+        )
     elif options.investments:
-        data = mint.get_investment_data()
+        data = mint.get_investment_data(
+            limit=options.limit,
+        )
     elif options.net_worth:
         data = mint.get_net_worth()
     elif options.credit_score:


### PR DESCRIPTION
As was discussed in a Discord thread, the default limit on each endpoint controlled by Mint is not large enough.  This PR addresses a couple items:

* Add support for a limit argument
* Add CLI support for a limit argument
* Set the default limit to 5000 records.