### PR TITLE
Backport passwordless login skip prompt

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -325,6 +325,7 @@ def sign_in(
     driver.implicitly_wait(1)  # seconds
     while not driver.current_url.startswith("https://mint.intuit.com/overview.event"):
         bypass_verified_user_page(driver)
+        bypass_passwordless_login_page(driver)
         mfa_page(
             driver,
             mfa_method,
@@ -406,6 +407,20 @@ def bypass_verified_user_page(driver):
         ElementNotInteractableException,
     ):
         pass
+
+
+def bypass_passwordless_login_page(driver):
+     # bypass "Sign in without a password next time" interstitial page
+     try:
+         skip_for_now = driver.find_element_by_id("skipWebauthnRegistration")
+         skip_for_now.click()
+     except (
+         NoSuchElementException,
+         StaleElementReferenceException,
+         ElementNotVisibleException,
+         ElementNotInteractableException,
+     ):
+         pass
 
 
 def mfa_page(


### PR DESCRIPTION
Backporting #436 to the 1.x release branch to allow skipping that for the old Mint UI.