### PR TITLE
[FEATURE] - Support multiple data types from CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@
 - Update the overview page url (#414) 
 
 BREAKING CHANGES:
-- :warning: `mfa_method` is only required if your login flow presents you with the option to select which Multifactor Authentication Method you wish to use, typically as a result of your account configured to accept different methods.  #392 provided a way to automatically detect the type of MFA requested by Mint, based on the prompts on the screen.  Because of this, Mintapi now supports the use case where multiple MFA prompts appear.
+- :warning: `mfa_method` is only required if your login flow presents you with the option to select which Multifactor Authentication Method you wish to use, typically as a result of your account configured to accept different methods.  #392 provided a way to automatically detect the type of MFA requested by Mint, based on the prompts on the screen.  Because of this, MintAPI now supports the use case where multiple MFA prompts appear.
 - Because of the new Mint UI and the switchover to different API Endpoints, the data structure associated with each function may be different.  Please verify that the data you are expecting against the new output of each endpoint.
 - To help support the new CLI option for data format (`--format`), we have eliminated the need to specify a file extension in `--filename`.  Be aware that if you do not specify `--format=csv`, then the extension\format will be `json`, which means that any filename you specify will include the extension of `.json`.
-
+- In addition to the above, the CLI now supports receiving multiple types of data in one call to MintAPI.  When exporting multiple data types, you can either send it directly to the `stdout` or you can export to a data file.  What MintAPI will do with your specified filename is add a suffix based on the type of data you are exporting.  For example, if you specify `current` as your filename and you export `account` and `transaction`, then you will receive two files: `current_account` and `current_transaction`.
 
 
 1.64

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An unofficial screen-scraping API for Mint.com.
 Please [join us on Discord](https://discord.gg/YjJEuJRAu9) to get help or just chat with fellow mintapi users :)
 
 ## Installation
+
 Ensure you have Python 3 and pip (`easy_install pip`) and then:
 
 ```shell
@@ -22,7 +23,7 @@ pip install mintapi
 
 ## Usage
 
-### from the command line
+### From the Command Line
 
 From the command line, the most automated invocation will be:
 
@@ -43,9 +44,11 @@ If you're running mintapi in a server environment on an automatic schedule, cons
 If you need to download the chromedriver manually, be sure to get the version that matches your chrome version and make the chromedriver available to your python interpreter either by putting the chromedriver in your python working directory or inside your `PATH` as described in the [python selenium documentation](https://www.selenium.dev/selenium/docs/api/py/index.html#drivers).
 
 ### General Automation Scenarios
+
 When running this inside of a cron job or other long-term automation scripts, it might be helpful to specify chrome and chromedriver executables so as not to conflict with other chrome versions you may have. Selenium by default just gets these from your `PATH` environment variable, so customizing your environment can force a deterministic behavior from mintapi. To use a different browser besides Chrome or Chromium, see the [python api](#from-python). Below are two examples.
 
 #### Unix Environment
+
 If I wanted to make sure that mintapi used the chromium executable in my /usr/bin directory when executing a cron job, I could write the following cron line:
 ```cron
 0 7 * * FRI PATH=/usr/bin:$PATH mintapi --headless john@example.com my_password
@@ -53,6 +56,7 @@ If I wanted to make sure that mintapi used the chromium executable in my /usr/bi
 where prepending the /usr/bin path to path will make those binaries found first. This will only affect the cron job and will not change the environment for any other process.
 
 #### Docker Image
+
 You can also use the docker image to help manage your environment so you don't have to worry about chrome or chromedriver versions. There are a few caveats:
 1. Headless mode is recommended. GUI works but introduces the need to configure an X11 server which varies with setup. Google is your friend.
 2. Almost always use the flag `--use-chromedriver-on-path` as the chrome and chromedriver built into the docker image already match and getting the latest will break the image.
@@ -64,7 +68,9 @@ docker run --rm --shm-size=2g ghcr.io/mintapi/mintapi mintapi john@example.com m
 ```
 
 #### Windows Environment
+
 You can do a similar thing in windows by executing the following in Powershell.
+
 ```powershell
 $ENV:PATH = "C:\Program Files\Google\Chrome;$ENV:PATH"
 mintapi --headless john@example.com my_password
@@ -80,7 +86,24 @@ If `mfa-method` is soft-token then you must also pass your `mfa-token`. The `mfa
 
 While Mint supports authentication via Voice, `mintapi` does not currently support this option.  Compatability with this method will be added in a later version.
 
-### from Python
+### Multi-Data Support
+
+As of v2.0, MintAPI supports returning multiple types of data in one call to MintAPI.  When exporting multiple data types, you can either send it directly to `stdout` or you can export to a data file.  What MintAPI will do with your specified filename is add a suffix based on the type of data you are exporting.  The following table outlines the option selected and its corresponding suffix:
+
+| Option       | Suffix       |
+| -----------  | -----------  |
+| accounts     | account      |
+| budgets      | budget       |
+| transactions | transaction  |
+| categories   | category     |
+| investments  | investment   |
+| net-worth    | net_worth    |
+| credit-score | credit_score |
+| credit-report| credit_report|
+
+For example, if you specify `current` as your filename, format as csv, and you export `account` and `transaction`, then you will receive two files: `current_account.csv` and `current_transaction.csv`.
+
+### From Python
 
 From python, instantiate the Mint class (from the mintapi package) and you can
 make calls to retrieve account/budget information.  We recommend using the

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
+import mintapi.constants as constants
 import logging
 import os
 import random
@@ -12,42 +13,37 @@ from mintapi.signIn import sign_in, _create_web_driver_at_mint_com
 
 logger = logging.getLogger("mintapi")
 
-ACCOUNT_KEY = "Account"
-BUDGET_KEY = "Budget"
-CATEGORY_KEY = "Category"
-INVESTMENT_KEY = "Investment"
-TRANSACTION_KEY = "Transaction"
 
 ENDPOINTS = {
-    ACCOUNT_KEY: {
+    constants.ACCOUNT_KEY: {
         "apiVersion": "pfm/v1",
         "endpoint": "accounts",
         "beginningDate": None,
         "endingDate": None,
         "includeCreatedDate": True,
     },
-    BUDGET_KEY: {
+    constants.BUDGET_KEY: {
         "apiVersion": "pfm/v1",
         "endpoint": "budgets",
         "beginningDate": "startDate",
         "endingDate": "endDate",
         "includeCreatedDate": True,
     },
-    CATEGORY_KEY: {
+    constants.CATEGORY_KEY: {
         "apiVersion": "pfm/v1",
         "endpoint": "categories",
         "beginningDate": None,
         "endingDate": None,
         "includeCreatedDate": False,
     },
-    INVESTMENT_KEY: {
+    constants.INVESTMENT_KEY: {
         "apiVersion": "pfm/v1",
         "endpoint": "investments",
         "beginningDate": None,
         "endingDate": None,
         "includeCreatedDate": False,
     },
-    TRANSACTION_KEY: {
+    constants.TRANSACTION_KEY: {
         "apiVersion": "pfm/v1",
         "endpoint": "transactions",
         "beginningDate": "fromDate",
@@ -236,20 +232,20 @@ class Mint(object):
         self,
         limit=5000,
     ):
-        return self.get_data(ACCOUNT_KEY, limit)
+        return self.get_data(constants.ACCOUNT_KEY, limit)
 
     def get_categories(
         self,
         limit=5000,
     ):
-        return self.get_data(CATEGORY_KEY, limit)
+        return self.get_data(constants.CATEGORY_KEY, limit)
 
     def get_budgets(
         self,
         limit=5000,
     ):
         return self.get_data(
-            BUDGET_KEY,
+            constants.BUDGET_KEY,
             limit,
             None,
             start_date=self.__x_months_ago(11),
@@ -261,7 +257,7 @@ class Mint(object):
         limit=5000,
     ):
         return self.get_data(
-            INVESTMENT_KEY,
+            constants.INVESTMENT_KEY,
             limit,
         )
 
@@ -289,7 +285,7 @@ class Mint(object):
             if include_investment:
                 id = 0
             data = self.get_data(
-                TRANSACTION_KEY,
+                constants.TRANSACTION_KEY,
                 limit,
                 id,
                 convert_mmddyy_to_datetime(start_date),

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -197,8 +197,11 @@ class Mint(object):
                 imap_folder,
             )
         except Exception as e:
+            msg = f"Could not sign in to Mint. Current page: {self.driver.current_url}"
             logger.exception(e)
             self.driver.quit()
+            self.driver = None
+            raise Exception(msg) from e
 
     def get_attention(self):
         attention = None

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -150,12 +150,6 @@ class Mint(object):
     def post(self, url, **kwargs):
         return self.driver.request("POST", url, **kwargs)
 
-    def make_post_request(self, url, data, convert_to_text=False):
-        response = self.post(url=url, data=data, headers=JSON_HEADER)
-        if convert_to_text:
-            response = response.text
-        return response
-
     def login_and_get_token(
         self,
         email,
@@ -326,7 +320,9 @@ class Mint(object):
         )
 
     def initiate_account_refresh(self):
-        self.make_post_request(url="{}/refreshFILogins.xevent".format(MINT_ROOT_URL))
+        self.post(
+            url="{}/refreshFILogins.xevent".format(MINT_ROOT_URL), headers=JSON_HEADER
+        )
 
     def get_credit_score(self):
         # Request a single credit report, and extract the score

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
-import mintapi.constants as constants
+from mintapi import constants
 import logging
 import os
 import random

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -4,7 +4,7 @@ import os
 import sys
 import json
 import getpass
-
+import mintapi.constants as constants
 import keyring
 import configargparse
 
@@ -13,9 +13,6 @@ from mintapi.signIn import get_email_code
 from pandas import json_normalize
 
 logger = logging.getLogger("mintapi")
-
-JSON_FORMAT = "json"
-CSV_FORMAT = "csv"
 
 
 def parse_arguments(args):
@@ -152,8 +149,8 @@ def parse_arguments(args):
         (
             ("--format",),
             {
-                "choices": [JSON_FORMAT, CSV_FORMAT],
-                "default": JSON_FORMAT,
+                "choices": [constants.JSON_FORMAT, constants.CSV_FORMAT],
+                "default": constants.JSON_FORMAT,
                 "help": "The format used to return data.",
             },
         ),
@@ -303,30 +300,30 @@ def handle_password(type, prompt, email, password, use_keyring=False):
     return password
 
 
-def format_filename(options):
+def format_filename(options, type):
     if options.filename is None:
         filename = None
     else:
-        filename = "{}.{}".format(options.filename, options.format)
+        filename = "{}_{}.{}".format(options.filename, type.lower(), options.format)
     return filename
 
 
-def output_data(options, data, attention_msg=None):
-    filename = format_filename(options)
+def output_data(options, data, type, attention_msg=None):
+    filename = format_filename(options, type)
     if filename is None:
-        if options.format == CSV_FORMAT:
+        if options.format == constants.CSV_FORMAT:
             print(json_normalize(data).to_csv(index=False))
         else:
             print(json.dumps(data, indent=2))
         # NOTE: While this logic is here, unless validate_file_extensions
         #       allows for other data types to export to CSV, this will
         #       only include investment data.
-    elif options.format == CSV_FORMAT:
+    elif options.format == constants.CSV_FORMAT:
         # NOTE: Currently, investment_data, which is a flat JSON, is the only
         #       type of data that uses this section.  So, if we open this up to
         #       other non-flat JSON data, we will need to revisit this.
         json_normalize(data).to_csv(filename, index=False)
-    elif options.format == JSON_FORMAT:
+    elif options.format == constants.JSON_FORMAT:
         with open(filename, "w+") as f:
             json.dump(data, f, indent=2)
 
@@ -416,63 +413,83 @@ def main():
         print("MFA CODE:", mfa_code)
         sys.exit()
 
-    data = None
-    if options.accounts and options.budgets:
+    attention_msg = None
+    if options.attention:
+        attention_msg = mint.get_attention()
+
+    if options.accounts:
         try:
             data = mint.get_account_data(limit=options.limit)
+            output_data(options, data, constants.ACCOUNT_KEY, attention_msg)
         except Exception:
-            accounts = None
+            data = None
 
-        try:
-            budgets = mint.get_budgets(limit=options.limit)
-        except Exception:
-            budgets = None
-
-        data = {"accounts": accounts, "budgets": budgets}
-    elif options.budgets:
+    if options.budgets:
         try:
             data = mint.get_budgets(limit=options.limit)
+            output_data(options, data, constants.BUDGET_KEY, attention_msg)
         except Exception:
             data = None
     elif options.budget_hist:
         try:
             data = mint.get_budgets(limit=options.limit, hist=12)
+            output_data(options, data, constants.BUDGET_KEY, attention_msg)
         except Exception:
             data = None
-    elif options.accounts:
-        try:
-            data = mint.get_account_data(limit=options.limit)
-        except Exception:
-            data = None
-    elif options.transactions:
-        data = mint.get_transaction_data(
-            limit=options.limit,
-            start_date=options.start_date,
-            end_date=options.end_date,
-            include_investment=options.include_investment,
-            remove_pending=options.show_pending,
-        )
-    elif options.categories:
-        data = mint.get_categories(
-            limit=options.limit,
-        )
-    elif options.investments:
-        data = mint.get_investment_data(
-            limit=options.limit,
-        )
-    elif options.net_worth:
-        data = mint.get_net_worth()
-    elif options.credit_score:
-        data = mint.get_credit_score()
-    elif options.credit_report:
-        data = mint.get_credit_report(
-            details=True,
-            exclude_inquiries=options.exclude_inquiries,
-            exclude_accounts=options.exclude_accounts,
-            exclude_utilization=options.exclude_utilization,
-        )
 
-    attention_msg = None
-    if options.attention:
-        attention_msg = mint.get_attention()
-    output_data(options, data, attention_msg)
+    if options.transactions:
+        try:
+            data = mint.get_transaction_data(
+                limit=options.limit,
+                start_date=options.start_date,
+                end_date=options.end_date,
+                include_investment=options.include_investment,
+                remove_pending=options.show_pending,
+            )
+            output_data(options, data, constants.TRANSACTION_KEY, attention_msg)
+        except Exception:
+            data = None
+
+    if options.categories:
+        try:
+            data = mint.get_categories(
+                limit=options.limit,
+            )
+            output_data(options, data, constants.CATEGORY_KEY, attention_msg)
+        except Exception:
+            data = None
+
+    if options.investments:
+        try:
+            data = mint.get_investment_data(
+                limit=options.limit,
+            )
+            output_data(options, data, constants.INVESTMENT_KEY, attention_msg)
+        except Exception:
+            data = None
+
+    if options.net_worth:
+        try:
+            data = mint.get_net_worth()
+            output_data(options, data, constants.NET_WORTH_KEY, attention_msg)
+        except Exception:
+            data = None
+
+    if options.credit_score:
+        try:
+            data = mint.get_credit_score()
+            output_data(options, data, constants.CREDIT_SCORE_KEY, attention_msg)
+        except Exception:
+            data = None
+
+    if options.credit_report:
+        try:
+            data = mint.get_credit_report(
+                details=True,
+                exclude_inquiries=options.exclude_inquiries,
+                exclude_accounts=options.exclude_accounts,
+                exclude_utilization=options.exclude_utilization,
+            )
+            output_data(options, data, constants.CREDIT_REPORT_KEY, attention_msg)
+        except Exception:
+            data = None

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -4,7 +4,7 @@ import os
 import sys
 import json
 import getpass
-import mintapi.constants as constants
+from mintapi import constants
 import keyring
 import configargparse
 
@@ -418,78 +418,51 @@ def main():
         attention_msg = mint.get_attention()
 
     if options.accounts:
-        try:
-            data = mint.get_account_data(limit=options.limit)
-            output_data(options, data, constants.ACCOUNT_KEY, attention_msg)
-        except Exception:
-            data = None
+        data = mint.get_account_data(limit=options.limit)
+        output_data(options, data, constants.ACCOUNT_KEY, attention_msg)
 
     if options.budgets:
-        try:
-            data = mint.get_budgets(limit=options.limit)
-            output_data(options, data, constants.BUDGET_KEY, attention_msg)
-        except Exception:
-            data = None
+        data = mint.get_budgets(limit=options.limit)
+        output_data(options, data, constants.BUDGET_KEY, attention_msg)
     elif options.budget_hist:
-        try:
-            data = mint.get_budgets(limit=options.limit, hist=12)
-            output_data(options, data, constants.BUDGET_KEY, attention_msg)
-        except Exception:
-            data = None
+        data = mint.get_budgets(limit=options.limit, hist=12)
+        output_data(options, data, constants.BUDGET_KEY, attention_msg)
 
     if options.transactions:
-        try:
-            data = mint.get_transaction_data(
-                limit=options.limit,
-                start_date=options.start_date,
-                end_date=options.end_date,
-                include_investment=options.include_investment,
-                remove_pending=options.show_pending,
-            )
-            output_data(options, data, constants.TRANSACTION_KEY, attention_msg)
-        except Exception:
-            data = None
+        data = mint.get_transaction_data(
+            limit=options.limit,
+            start_date=options.start_date,
+            end_date=options.end_date,
+            include_investment=options.include_investment,
+            remove_pending=options.show_pending,
+        )
+        output_data(options, data, constants.TRANSACTION_KEY, attention_msg)
 
     if options.categories:
-        try:
-            data = mint.get_categories(
-                limit=options.limit,
-            )
-            output_data(options, data, constants.CATEGORY_KEY, attention_msg)
-        except Exception:
-            data = None
+        data = mint.get_categories(
+            limit=options.limit,
+        )
+        output_data(options, data, constants.CATEGORY_KEY, attention_msg)
 
     if options.investments:
-        try:
-            data = mint.get_investment_data(
-                limit=options.limit,
-            )
-            output_data(options, data, constants.INVESTMENT_KEY, attention_msg)
-        except Exception:
-            data = None
+        data = mint.get_investment_data(
+            limit=options.limit,
+        )
+        output_data(options, data, constants.INVESTMENT_KEY, attention_msg)
 
     if options.net_worth:
-        try:
-            data = mint.get_net_worth()
-            output_data(options, data, constants.NET_WORTH_KEY, attention_msg)
-        except Exception:
-            data = None
+        data = mint.get_net_worth()
+        output_data(options, data, constants.NET_WORTH_KEY, attention_msg)
 
     if options.credit_score:
-        try:
-            data = mint.get_credit_score()
-            output_data(options, data, constants.CREDIT_SCORE_KEY, attention_msg)
-        except Exception:
-            data = None
+        data = mint.get_credit_score()
+        output_data(options, data, constants.CREDIT_SCORE_KEY, attention_msg)
 
     if options.credit_report:
-        try:
-            data = mint.get_credit_report(
-                details=True,
-                exclude_inquiries=options.exclude_inquiries,
-                exclude_accounts=options.exclude_accounts,
-                exclude_utilization=options.exclude_utilization,
-            )
-            output_data(options, data, constants.CREDIT_REPORT_KEY, attention_msg)
-        except Exception:
-            data = None
+        data = mint.get_credit_report(
+            details=True,
+            exclude_inquiries=options.exclude_inquiries,
+            exclude_accounts=options.exclude_accounts,
+            exclude_utilization=options.exclude_utilization,
+        )
+        output_data(options, data, constants.CREDIT_REPORT_KEY, attention_msg)

--- a/mintapi/constants.py
+++ b/mintapi/constants.py
@@ -1,0 +1,11 @@
+JSON_FORMAT = "json"
+CSV_FORMAT = "csv"
+
+ACCOUNT_KEY = "Account"
+BUDGET_KEY = "Budget"
+CATEGORY_KEY = "Category"
+INVESTMENT_KEY = "Investment"
+TRANSACTION_KEY = "Transaction"
+NET_WORTH_KEY = "Net_Worth"
+CREDIT_SCORE_KEY = "Credit_Score"
+CREDIT_REPORT_KEY = "Credit_Report"

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -272,8 +272,10 @@ class MintApiTests(unittest.TestCase):
     ):
         test_exception = Exception()
         mock_sign_in.side_effect = test_exception
-        mintapi.Mint("test", "test")
+        with self.assertRaises(Exception) as context:
+            mintapi.Mint("test", "test")
         mock_logger.exception.assert_called_with(test_exception)
+        self.assertTrue("Could not sign in to Mint" in str(context.exception))
 
     @patch.multiple(
         mintapi.Mint,

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -5,7 +5,7 @@ import json
 import unittest
 import requests
 import tempfile
-import mintapi.constants as constants
+from mintapi import constants
 from unittest.mock import patch, DEFAULT
 
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -5,7 +5,7 @@ import json
 import unittest
 import requests
 import tempfile
-
+import mintapi.constants as constants
 from unittest.mock import patch, DEFAULT
 
 
@@ -357,29 +357,31 @@ class MintApiTests(unittest.TestCase):
     def test_format_filename(self):
         config_file = write_transactions_file()
         arguments = parse_arguments_file(config_file)
-        filename = mintapi.cli.format_filename(arguments)
-        self.assertEqual(filename, "transactions.csv")
+        type = constants.TRANSACTION_KEY.lower()
+        filename = mintapi.cli.format_filename(arguments, type)
+        self.assertEqual(filename, "current_{}.csv".format(type))
 
         config_file = write_accounts_file()
         arguments = parse_arguments_file(config_file)
-        filename = mintapi.cli.format_filename(arguments)
-        self.assertEqual(filename, "accounts.json")
+        type = constants.ACCOUNT_KEY.lower()
+        filename = mintapi.cli.format_filename(arguments, type)
+        self.assertEqual(filename, "current_{}.json".format(type))
 
         config_file = write_investments_file()
         arguments = parse_arguments_file(config_file)
-        filename = mintapi.cli.format_filename(arguments)
+        filename = mintapi.cli.format_filename(arguments, None)
         self.assertEqual(filename, None)
 
 
 def write_transactions_file():
     config_file = tempfile.NamedTemporaryFile(mode="wt")
-    config_file.write("transactions\nformat=csv\nfilename=transactions")
+    config_file.write("transactions\nformat=csv\nfilename=current")
     return config_file
 
 
 def write_accounts_file():
     config_file = tempfile.NamedTemporaryFile(mode="wt")
-    config_file.write("accounts\nformat=json\nfilename=accounts")
+    config_file.write("accounts\nformat=json\nfilename=current")
     return config_file
 
 


### PR DESCRIPTION
The CLI has been refactored to support exporting multiple data types in one command.  When exporting multiple data types, you can either send it directly to the `stdout` or you can export to a data file. What MintAPI will do with your specified filename is add a suffix based on the type of data you are exporting. The following table outlines the option selected and its corresponding suffix:

| Option       | Suffix       |
| -----------  | -----------  |
| accounts     | account      |
| budgets      | budget       |
| transactions | transaction  |
| categories   | category     |
| investments  | investment   |
| net-worth    | net_worth    |
| credit-score | credit_score |
| credit-report| credit_report|

For example, if you specify `current` as your filename, format as csv, and you export `account` and `transaction`, then you will receive two files: `current_account.csv` and `current_transaction.csv`.