### PR TITLE
[FIX] - Use url_contains instead of url_changed

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -370,7 +370,7 @@ def sign_in(
         password_page(driver, password)
         # Give the overview page a chance to actually load
         WebDriverWait(driver, 5).until(
-            expected_conditions.url_changes("https://mint.intuit.com/overview")
+            expected_conditions.url_contains("https://mint.intuit.com/overview")
         )
 
     driver.implicitly_wait(20)  # seconds


### PR DESCRIPTION
As a follow-up to #448 , more testing showed that we should use `url_contains` instead of `url_changed` for managing the explicit wait.