### PR TITLE
Account for the click of your MFA method

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -34,6 +34,7 @@ MFA_VIA_AUTHENTICATOR = "authenticator"
 MFA_VIA_EMAIL = "email"
 MFA_VIA_SMS = "sms"
 MFA_METHOD_LABEL = "mfa_method"
+SELECT_CSS_SELECTORS_LABEL = "select_css_selectors"
 INPUT_CSS_SELECTORS_LABEL = "input_css_selectors"
 SPAN_CSS_SELECTORS_LABEL = "span_css_selectors"
 BUTTON_CSS_SELECTORS_LABEL = "button_css_selectors"
@@ -41,25 +42,29 @@ BUTTON_CSS_SELECTORS_LABEL = "button_css_selectors"
 MFA_METHODS = [
     {
         MFA_METHOD_LABEL: MFA_VIA_SOFT_TOKEN,
+        SELECT_CSS_SELECTORS_LABEL: '#iux-mfa-soft-token-verification-code, #ius-mfa-soft-token, [data-testid="VerifySoftTokenInput"]',
         INPUT_CSS_SELECTORS_LABEL: '#iux-mfa-soft-token-verification-code, #ius-mfa-soft-token, [data-testid="VerifySoftTokenInput"]',
         SPAN_CSS_SELECTORS_LABEL: "",
         BUTTON_CSS_SELECTORS_LABEL: '#ius-mfa-soft-token-submit-btn, [data-testid="VerifySoftTokenSubmitButton"]',
     },
     {
         MFA_METHOD_LABEL: MFA_VIA_AUTHENTICATOR,
+        SELECT_CSS_SELECTORS_LABEL: '#iux-mfa-soft-token-verification-code, #ius-mfa-soft-token, [data-testid="VerifySoftTokenInput"]',
         INPUT_CSS_SELECTORS_LABEL: '#iux-mfa-soft-token-verification-code, #ius-mfa-soft-token, [data-testid="VerifySoftTokenInput"]',
         SPAN_CSS_SELECTORS_LABEL: '[data-testid="VerifySoftTokenSubHeader"]',
         BUTTON_CSS_SELECTORS_LABEL: '#ius-mfa-soft-token-submit-btn, [data-testid="VerifySoftTokenSubmitButton"]',
     },
     {
         MFA_METHOD_LABEL: MFA_VIA_EMAIL,
-        INPUT_CSS_SELECTORS_LABEL: "#ius-label-mfa-email-otp, #ius-mfa-email-otp-card-challenge, #ius-sublabel-mfa-email-otp, #ius-mfa-confirm-code",
+        SELECT_CSS_SELECTORS_LABEL: "#ius-label-mfa-email-otp, #ius-mfa-email-otp-card-challenge, #ius-sublabel-mfa-email-otp",
+        INPUT_CSS_SELECTORS_LABEL: "#ius-mfa-confirm-code",
         SPAN_CSS_SELECTORS_LABEL: '[data-testid="VerifyOtpHeaderText"]',
         BUTTON_CSS_SELECTORS_LABEL: '#ius-mfa-otp-submit-btn, [data-testid="VerifyOtpSubmitButton"]',
     },
     {
         MFA_METHOD_LABEL: MFA_VIA_SMS,
-        INPUT_CSS_SELECTORS_LABEL: "#ius-mfa-sms-otp-card-challenge, #ius-mfa-confirm-code",
+        SELECT_CSS_SELECTORS_LABEL: "#ius-mfa-sms-otp-card-challenge",
+        INPUT_CSS_SELECTORS_LABEL: "#ius-mfa-confirm-code",
         SPAN_CSS_SELECTORS_LABEL: '[data-testid="VerifyOtpHeaderText"]',
         BUTTON_CSS_SELECTORS_LABEL: '#ius-mfa-otp-submit-btn, [data-testid="VerifyOtpSubmitButton"]',
     },
@@ -514,6 +519,10 @@ def search_mfa_method(driver):
     for method in MFA_METHODS:
         mfa_token_input = mfa_token_button = mfa_method = span_text = result = None
         try:
+            mfa_token_select = driver.find_element_by_css_selector(
+                method[SELECT_CSS_SELECTORS_LABEL]
+            )
+            mfa_token_select.click()
             mfa_token_input = driver.find_element_by_css_selector(
                 method[INPUT_CSS_SELECTORS_LABEL]
             )
@@ -540,6 +549,10 @@ def set_mfa_method(driver, mfa_method):
     )
     mfa_result = list(mfa)[0]
     try:
+        mfa_token_select = driver.find_element_by_css_selector(
+            mfa_result[SELECT_CSS_SELECTORS_LABEL]
+        )
+        mfa_token_select.click()
         mfa_token_input = driver.find_element_by_css_selector(
             mfa_result[INPUT_CSS_SELECTORS_LABEL]
         )

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -377,14 +377,12 @@ def sign_in(
 
         count = count + 1
         if count > 10:
-            if 'Intuit Accounts - Sign In' in driver.page_source.encode('ascii', 'replace').decode('ascii'):
-                raise RuntimeError(
-                    "Login to Mint failed"
-                )
+            if "Intuit Accounts - Sign In" in driver.page_source.encode(
+                "ascii", "replace"
+            ).decode('ascii'):
+                raise RuntimeError("Login to Mint failed")
             else:
-                raise RuntimeError(
-                    "Timeout while logging in"
-                )
+                raise RuntimeError("Timeout while logging in")
 
     driver.implicitly_wait(20)  # seconds
     # Wait until the overview page has actually loaded, and if wait_for_sync==True, sync has completed.

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -379,7 +379,7 @@ def sign_in(
         if count > 10:
             if "Intuit Accounts - Sign In" in driver.page_source.encode(
                 "ascii", "replace"
-            ).decode('ascii'):
+            ).decode("ascii"):
                 raise RuntimeError("Login to Mint failed")
             else:
                 raise RuntimeError("Timeout while logging in")

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -363,9 +363,9 @@ def sign_in(
             ):
                 # no need to enter credentials, likely alreadly logged in
                 pass
+            driver.implicitly_wait(1)  # seconds
 
         # Wait until logged in, just in case we need to deal with MFA.
-        driver.implicitly_wait(1)  # seconds
 
         if not bypass_verified_user_page(driver):
             # if bypass_verified_user_page was present, then MFA already done

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -540,10 +540,6 @@ def search_mfa_method(driver):
     for method in MFA_METHODS:
         mfa_token_input = mfa_token_button = mfa_method = span_text = result = None
         try:
-            mfa_token_select = driver.find_element_by_css_selector(
-                method[SELECT_CSS_SELECTORS_LABEL]
-            )
-            mfa_token_select.click()
             mfa_token_input = driver.find_element_by_css_selector(
                 method[INPUT_CSS_SELECTORS_LABEL]
             )


### PR DESCRIPTION
With email MFA, one first needs to click “Email a code” to start the email MFA.  This PR adds this click.  The current code conflates the ids used for clicking “Email a code” with the ids for entering the code as INPUT_CSS_SELECTORS_LABEL.  I separated out the ids for clicking “Email a code” into SELECT_CSS_SELECTORS_LABEL and added the click.

This PR has only been tested for MFA via email.  I don’t have access to the other authentication types.  Looking at the 1.66 branch, it appears that this initial click is not needed for soft token or authenticator MFA.  Somebody needs to verify that this PR did not break these MFA methods.
