### PR TITLE
[FIX] - Typo on soft-token constant

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -29,7 +29,7 @@ import oathtool
 
 logger = logging.getLogger("mintapi")
 
-MFA_VIA_SOFT_TOKEN = "soft_token"
+MFA_VIA_SOFT_TOKEN = "soft-token"
 MFA_VIA_AUTHENTICATOR = "authenticator"
 MFA_VIA_EMAIL = "email"
 MFA_VIA_SMS = "sms"


### PR DESCRIPTION
When implementing https://github.com/mintapi/mintapi/pull/392, a constant was created for the soft token MFA Method.  However, an underscore was used (i.e. `soft_token`) instead of a dash (i.e. `soft-token`).