### PR TITLE
[FIX] - Format Net Worth Before Sending to Output Data

### DIFF
--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -452,7 +452,8 @@ def main():
 
     if options.net_worth:
         data = mint.get_net_worth()
-        output_data(options, data, constants.NET_WORTH_KEY, attention_msg)
+        formatted_data = {"net_worth": data}
+        output_data(options, formatted_data, constants.NET_WORTH_KEY, attention_msg)
 
     if options.credit_score:
         data = mint.get_credit_score()


### PR DESCRIPTION
Net Worth is returned as a simple number.  So when it gets to `output_data`, it's failing because it's not in any sort of format.  This PR adds a format to the net worth data before sent to the common `output_data` method.