### PR TITLE
[CHORE] - Update the README, CHANGELOG and more tidying of method names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BREAKING CHANGES:
 - Because of the new Mint UI and the switchover to different API Endpoints, the data structure associated with each function may be different.  Please verify that the data you are expecting against the new output of each endpoint.
 - To help support the new CLI option for data format (`--format`), we have eliminated the need to specify a file extension in `--filename`.  Be aware that if you do not specify `--format=csv`, then the extension\format will be `json`, which means that any filename you specify will include the extension of `.json`.
 - In addition to the above, the CLI now supports receiving multiple types of data in one call to MintAPI.  When exporting multiple data types, you can either send it directly to the `stdout` or you can export to a data file.  What MintAPI will do with your specified filename is add a suffix based on the type of data you are exporting.  For example, if you specify `current` as your filename and you export `account` and `transaction`, then you will receive two files: `current_account` and `current_transaction`.
+- You will note that to implement consistency and to call attention to the fact that some input and outputs of the primary methods to fetch Mint data has changed, the API methods for each data type may be different.  However, (with the exception of bills), all data fetch methods follow the same sort of pattern, i.e. `get_<data type>_data`.  For example, instead of `get_accounts`, we now have `get_account_data`.
 
 
 1.64

--- a/README.md
+++ b/README.md
@@ -145,35 +145,31 @@ make calls to retrieve account/budget information.  We recommend using the
 	                                 # is on the PATH (instead of downloading the latest version)
   )
 
-  # Get basic account information
-  mint.get_accounts()
-
-  # Get extended account detail at the expense of speed - requires an
-  # additional API call for each account
-  mint.get_accounts(True)
+  # Get account information
+  mint.get_account_data()
 
   # Get budget information
-  mint.get_budgets()
+  mint.get_budget_data()
 
   # Get transactions
   mint.get_transaction_data() # as pandas dataframe
 
   # Get transactions for a specific account
-  accounts = mint.get_accounts(True)
+  accounts = mint.get_account_data()
   for account in accounts:
     mint.get_transaction_data(id=account["id"])
 
   # Get net worth
-  mint.get_net_worth()
+  mint.get_net_worth_data()
 
   # Get credit score
-  mint.get_credit_score()
+  mint.get_credit_score_data()
 
   # Get bills
   mint.get_bills()
 
   # Get investments (holdings and transactions)
-  mint.get_invests_json()
+  mint.get_investment_data()
 
   # Close session and exit cleanly from selenium/chromedriver
   mint.close()

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -234,13 +234,13 @@ class Mint(object):
     ):
         return self.get_data(constants.ACCOUNT_KEY, limit)
 
-    def get_categories(
+    def get_category_data(
         self,
         limit=5000,
     ):
         return self.get_data(constants.CATEGORY_KEY, limit)
 
-    def get_budgets(
+    def get_budget_data(
         self,
         limit=5000,
     ):
@@ -301,7 +301,7 @@ class Mint(object):
             raise Exception
         return data
 
-    def get_net_worth(self, account_data=None):
+    def get_net_worth_data(self, account_data=None):
         if account_data is None:
             account_data = self.get_account_data()
 
@@ -320,9 +320,9 @@ class Mint(object):
             url="{}/refreshFILogins.xevent".format(MINT_ROOT_URL), headers=JSON_HEADER
         )
 
-    def get_credit_score(self):
+    def get_credit_score_data(self):
         # Request a single credit report, and extract the score
-        report = self.get_credit_report(
+        report = self.get_credit_report_data(
             limit=1,
             details=False,
             exclude_inquiries=False,
@@ -335,7 +335,7 @@ class Mint(object):
         except (KeyError, IndexError):
             raise Exception("No Credit Score Found")
 
-    def get_credit_report(
+    def get_credit_report_data(
         self,
         limit=2,
         details=True,

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -422,10 +422,10 @@ def main():
         output_data(options, data, constants.ACCOUNT_KEY, attention_msg)
 
     if options.budgets:
-        data = mint.get_budgets(limit=options.limit)
+        data = mint.get_budget_data(limit=options.limit)
         output_data(options, data, constants.BUDGET_KEY, attention_msg)
     elif options.budget_hist:
-        data = mint.get_budgets(limit=options.limit, hist=12)
+        data = mint.get_budget_data(limit=options.limit, hist=12)
         output_data(options, data, constants.BUDGET_KEY, attention_msg)
 
     if options.transactions:
@@ -439,7 +439,7 @@ def main():
         output_data(options, data, constants.TRANSACTION_KEY, attention_msg)
 
     if options.categories:
-        data = mint.get_categories(
+        data = mint.get_category_data(
             limit=options.limit,
         )
         output_data(options, data, constants.CATEGORY_KEY, attention_msg)
@@ -451,15 +451,15 @@ def main():
         output_data(options, data, constants.INVESTMENT_KEY, attention_msg)
 
     if options.net_worth:
-        data = mint.get_net_worth()
+        data = mint.get_net_worth_data()
         output_data(options, data, constants.NET_WORTH_KEY, attention_msg)
 
     if options.credit_score:
-        data = mint.get_credit_score()
+        data = mint.get_credit_score_data()
         output_data(options, data, constants.CREDIT_SCORE_KEY, attention_msg)
 
     if options.credit_report:
-        data = mint.get_credit_report(
+        data = mint.get_credit_report_data(
             details=True,
             exclude_inquiries=options.exclude_inquiries,
             exclude_accounts=options.exclude_accounts,

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -288,27 +288,27 @@ class MintApiTests(unittest.TestCase):
     )
     def test_exclude_credit_details(self, **_):
         mint = mintapi.Mint()
-        credit_report = mint.get_credit_report(
+        credit_report = mint.get_credit_report_data(
             limit=2, details=True, exclude_inquiries=True
         )
         self.assertFalse("inquiries" in credit_report)
-        credit_report = mint.get_credit_report(
+        credit_report = mint.get_credit_report_data(
             limit=2, details=True, exclude_inquiries=False
         )
         self.assertTrue("inquiries" in credit_report)
-        credit_report = mint.get_credit_report(
+        credit_report = mint.get_credit_report_data(
             limit=2, details=True, exclude_accounts=True
         )
         self.assertFalse("accounts" in credit_report)
-        credit_report = mint.get_credit_report(
+        credit_report = mint.get_credit_report_data(
             limit=2, details=True, exclude_accounts=False
         )
         self.assertTrue("accounts" in credit_report)
-        credit_report = mint.get_credit_report(
+        credit_report = mint.get_credit_report_data(
             limit=2, details=True, exclude_utilization=True
         )
         self.assertFalse("utilization" in credit_report)
-        credit_report = mint.get_credit_report(
+        credit_report = mint.get_credit_report_data(
             limit=2, details=True, exclude_utilization=False
         )
         self.assertTrue("utilization" in credit_report)
@@ -349,7 +349,7 @@ class MintApiTests(unittest.TestCase):
     @patch.object(mintapi.Mint, "_Mint__call_mint_endpoint")
     def test_get_budgets(self, mock_call_budgets_endpoint):
         mock_call_budgets_endpoint.return_value = budgets_example
-        budgets = mintapi.Mint().get_budgets()[0]
+        budgets = mintapi.Mint().get_budget_data()[0]
         self.assertFalse("metaData" in budgets)
         self.assertTrue("createdDate" in budgets)
         self.assertTrue("lastUpdatedDate" in budgets)


### PR DESCRIPTION
As discussed on #458 , the names of the methods have changed from v1 and so we need some updates to the README, more explicit callout in the CHANGELOG, and we need to make some more tweaks\tidying to the actual method names to ensure consistency.  Note that `get_bills` is an exception because it does NOT use the same execution structure as the others.