### PR TITLE
[FEATURE] - Add support for routing to Mint beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
 
 ```shell
     usage: mintapi [-h] [--session-path [SESSION_PATH]] [--accounts] [--investment]
-                   [--budgets | --budget_hist] [--net-worth] [--extended-accounts] 
+                   [--beta] [--budgets | --budget_hist] [--net-worth] [--extended-accounts] 
                    [--transactions] [--credit-score] [--credit-report]
                    [--exclude-inquiries] [--exclude-accounts] [--exclude-utilization]
                    [--start-date [START_DATE]] [--end-date [END_DATE]]
@@ -237,6 +237,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
                             Directory to save browser session, including cookies. Used to prevent repeated
                             MFA prompts. Defaults to $HOME/.mintapi/session. Set to None to use a temporary
                             profile.
+      --beta                Use the beta version of Mint
       --budgets             Retrieve budget information for current month
       --budget_hist         Retrieve historical budget information (past 12 months)
       --categories          Retrieve your configured Mint categories

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ An unofficial screen-scraping API for Mint.com.
 
 We recently released 2.0, which supports (and only supports) the new Mint UI:
 
- * If your account still has the original UI with the nav on *top*, please install the latest 1.x release: `pip install mintapi<2.0`
  * If your account has the new UI with the nav on the *left*, you'll need to install at least 2.0: `pip install mintapi>=2.0`
+ * If your account still has the original UI with the nav on *top*, to use 2.0, you will need to specify `--beta` in your command-line options or submit `beta=True` when initializing the class.  Otherwise, please install the latest 1.x release: `pip install mintapi<2.0`
 
 Please note that due to data changes on the Mint.com side as well as various new features and changes on the mintapi side, there are several breaking changes in 2.0. Please see [the CHANGELOG](https://github.com/mintapi/mintapi/blob/main/CHANGELOG.md) for details.
 

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -86,6 +86,7 @@ class Mint(object):
         use_chromedriver_on_path=False,
         chromedriver_download_path=os.getcwd(),
         driver=None,
+        beta=False,
     ):
         self.driver = None
         self.status_message = None
@@ -109,6 +110,7 @@ class Mint(object):
                 use_chromedriver_on_path=use_chromedriver_on_path,
                 chromedriver_download_path=chromedriver_download_path,
                 driver=driver,
+                beta=beta,
             )
 
     def _get_api_key_header(self):
@@ -153,6 +155,7 @@ class Mint(object):
         use_chromedriver_on_path=False,
         chromedriver_download_path=os.getcwd(),
         driver=None,
+        beta=False,
     ):
 
         self.driver = driver or _create_web_driver_at_mint_com(
@@ -174,6 +177,7 @@ class Mint(object):
                 imap_password,
                 imap_server,
                 imap_folder,
+                beta,
             )
         except Exception as e:
             msg = f"Could not sign in to Mint. Current page: {self.driver.current_url}"

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -50,6 +50,14 @@ def parse_arguments(args):
             },
         ),
         (
+            ("--beta",),
+            {
+                "action": "store_true",
+                "default": False,
+                "help": "Use the beta version of Mint",
+            },
+        ),
+        (
             ("--budgets",),
             {
                 "action": "store_true",
@@ -403,6 +411,7 @@ def main():
         wait_for_sync_timeout=options.wait_for_sync_timeout,
         use_chromedriver_on_path=options.use_chromedriver_on_path,
         chromedriver_download_path=options.chromedriver_download_path,
+        beta=options.beta,
     )
     atexit.register(mint.close)  # Ensure everything is torn down.
 

--- a/mintapi/constants.py
+++ b/mintapi/constants.py
@@ -11,6 +11,7 @@ CREDIT_SCORE_KEY = "Credit_Score"
 CREDIT_REPORT_KEY = "Credit_Report"
 
 MINT_ROOT_URL = "https://mint.intuit.com"
+MINT_BETA_ROOT_URL = "https://beta.mint.intuit.com"
 MINT_CREDIT_URL = "https://credit.finance.intuit.com"
 
 JSON_HEADER = {"accept": "application/json"}

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -317,14 +317,20 @@ def sign_in(
     imap_password=None,
     imap_server=None,
     imap_folder="INBOX",
+    beta=False,
 ):
+    if beta:
+        url = constants.MINT_BETA_ROOT_URL
+    else:
+        url = constants.MINT_ROOT_URL
     """
     Takes in a web driver and gets it through the Mint sign in process
     """
     driver.implicitly_wait(20)  # seconds
-    driver.get("https://www.mint.com")
-    element = driver.find_element_by_link_text("Sign in")
-    element.click()
+    driver.get(url)
+    if not beta:
+        element = driver.find_element_by_link_text("Sign in")
+        element.click()
 
     WebDriverWait(driver, 20).until(
         expected_conditions.presence_of_element_located(
@@ -340,7 +346,7 @@ def sign_in(
 
     driver.implicitly_wait(1)  # seconds
     count = 0
-    while not driver.current_url.startswith("https://mint.intuit.com/overview"):
+    while not driver.current_url.startswith("{}/".format(url)):
         try:  # try to enter in credentials if username and password are on same page
             handle_same_page_username_password(driver, email, password)
         except (
@@ -384,7 +390,7 @@ def sign_in(
         # If it doesn't, then there may be another round of MFA.
         try:
             WebDriverWait(driver, 5).until(
-                expected_conditions.url_contains("https://mint.intuit.com/overview")
+                expected_conditions.url_contains("{}/".format(url))
             )
         except Exception:
             count += 1


### PR DESCRIPTION
The biggest pain point of Mint's rollout of the new UI is not everyone has the rollout.  Thanks to a user's observation, the URL of `beta.mint.intuit.com` does route to the new UI.  So, this PR adds support for the tool to route to the beta URL instead of the normal URL, with the hopes of giving support for those users whose accounts are still on the old UI.