### PR TITLE
Support optional MFA if remember my device is enabled

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -510,7 +510,12 @@ def mfa_page(
     if mfa_method is None:
         mfa_result = search_mfa_method(driver)
     else:
-        mfa_result = set_mfa_method(driver, mfa_method)
+        try:
+            mfa_result = set_mfa_method(driver, mfa_method)
+        except Exception as e:
+            # MFA is optional for devices that were registered to Mint by clicking on "Remember my device"
+            logger.info(str(e))
+            return
     mfa_token_input = mfa_result[0]
     mfa_token_button = mfa_result[1]
     mfa_method = mfa_result[2]


### PR DESCRIPTION
If you enable "Remember my device" then MFA will become optional. If you specify the preferred MFA method through the `mfa-method` setting then if MFA page won't appear then you'll get a `RuntimeException`. When "Remember my device" is enabled MFA page is not expected to show up.