### PR TITLE
[FIX] - Add missing driver to find_element to fix issue with signing in

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -448,7 +448,7 @@ def handle_same_page_username_password(driver, email, password):
 
 def handle_different_page_username_password(driver, email):
     try:
-        email_input = find_element(
+        email_input = driver.find_element(
             By.CSS_SELECTOR,
             '#ius-identifier, [data-testid="IdentifierFirstIdentifierInput"]',
         )


### PR DESCRIPTION
This PR fixes the issue described in #499 since the `find_element` method is missing the driver.