### PR TITLE
require latest version of selenium for find_element

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         "oathtool",
         "pandas>=1.0",
         "requests",
-        "selenium<5.0.0",
+        "selenium>=4.3.0,<5.0.0",
         "selenium-requests>=1.3.3",
         "xmltodict",
         "keyring",


### PR DESCRIPTION
This is so driver.find_element exists for everyone. I'm not sure which version this was first introduced, but I don't see a huge problem in requiring at least 4.3.0. Do we need anything in requirements.txt?