### PR TITLE
[CHORE] - Move general filters to its own class instance

### DIFF
--- a/mintapi/filters.py
+++ b/mintapi/filters.py
@@ -1,0 +1,96 @@
+"""
+General Filters helper classes
+"""
+
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class MatchFilter(metaclass=ABCMeta):
+    @abstractmethod
+    def to_dict(self):
+        pass
+
+
+@dataclass
+class CategoryIdFilter(MatchFilter):
+    value: str
+    include_child_categories: bool
+
+    def to_dict(self):
+        return {
+            "type": "CategoryIdFilter",
+            "categoryId": self.value,
+            "includeChildCategories": self.include_child_categories,
+        }
+
+
+@dataclass
+class CategoryNameFilter(MatchFilter):
+    value: str
+    include_child_categories: bool
+
+    def to_dict(self):
+        return {
+            "type": "CategoryNameFilter",
+            "categoryName": self.value,
+            "includeChildCategories": self.include_child_categories,
+            "exclude": True,
+        }
+
+
+@dataclass
+class DescriptionNameFilter(MatchFilter):
+    value: str
+
+    def to_dict(self):
+        return {"type": "DescriptionNameFilter", "description": self.value}
+
+
+@dataclass
+class TagIdFilter(MatchFilter):
+    value: str
+
+    def to_dict(self):
+        return {"type": "TagIdFilter", "tagId": self.value}
+
+
+@dataclass
+class TagNameFilter(MatchFilter):
+    value: str
+
+    def to_dict(self):
+        return {"type": "TagNameFilter", "tagName": self.value, "exclude": True}
+
+
+@dataclass
+class SearchFilter:
+    """
+    Search filters are composites of match any or match all clauses
+    param: matchAll -> true or false
+    """
+
+    match_all_filters: List[MatchFilter] = field(default_factory=list)
+    match_any_filters: List[MatchFilter] = field(default_factory=list)
+
+    def to_dict(self):
+        return {
+            "searchFilters": [
+                {
+                    "matchAll": True,
+                    "filters": [
+                        match_filter.to_dict()
+                        for match_filter in self.match_all_filters
+                    ],
+                },
+                {
+                    "matchAll": False,
+                    "filters": [
+                        match_filter.to_dict()
+                        for match_filter in self.match_any_filters
+                    ],
+                },
+            ]
+        }

--- a/mintapi/trends.py
+++ b/mintapi/trends.py
@@ -2,10 +2,10 @@
 Trends helper classes
 """
 
-from abc import ABCMeta, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Union
+from typing import Optional, Union
+from mintapi.filters import SearchFilter
 
 
 @dataclass
@@ -96,73 +96,6 @@ class DateFilter:
             filter_clause["dateFilter"]["startDate"] = self.start_date
             filter_clause["dateFilter"]["endDate"] = self.end_date
         return filter_clause
-
-
-@dataclass
-class MatchFilter(metaclass=ABCMeta):
-    @abstractmethod
-    def to_dict(self):
-        pass
-
-
-@dataclass
-class CategoryMatchFilter(MatchFilter):
-    category_id: str
-    include_child_categories: bool
-
-    def to_dict(self):
-        return {
-            "type": "CategoryIdFilter",
-            "categoryId": self.category_id,
-            "includeChildCategories": self.include_child_categories,
-        }
-
-
-@dataclass
-class DescriptionMatchFilter(MatchFilter):
-    description: str
-
-    def to_dict(self):
-        return {"type": "DescriptionNameFilter", "description": self.description}
-
-
-@dataclass
-class TagMatchFilter(MatchFilter):
-    tag_id: str
-
-    def to_dict(self):
-        return {"type": "TagIdFilter", "tagId": self.tag_id}
-
-
-@dataclass
-class SearchFilter:
-    """
-    Search filters are composites of match any or match all clauses
-    param: matchAll -> true or false
-    """
-
-    match_all_filters: List[MatchFilter] = field(default_factory=list)
-    match_any_filters: List[MatchFilter] = field(default_factory=list)
-
-    def to_dict(self):
-        return {
-            "searchFilters": [
-                {
-                    "matchAll": True,
-                    "filters": [
-                        match_filter.to_dict()
-                        for match_filter in self.match_all_filters
-                    ],
-                },
-                {
-                    "matchAll": False,
-                    "filters": [
-                        match_filter.to_dict()
-                        for match_filter in self.match_any_filters
-                    ],
-                },
-            ]
-        }
 
 
 @dataclass


### PR DESCRIPTION
In preparation for supporting the Transactions Search Endpoint, we should do a little refactoring to keep the Transactions changes as minimal as possible.  This PR addresses creating `filters.py`, which multiple classes can then reference instead of duplicating work.