### PR TITLE
[FIX] email as the only MFA randomly fails and other issues

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -116,16 +116,17 @@ def get_email_code(imap_account, imap_password, imap_server, imap_folder, delete
 
             msg = email.message_from_bytes(data[0][1])
 
+            x = email.header.make_header(email.header.decode_header(msg["Subject"]))
+
+            subject = str(x)
+            logger.debug("DEBUG: SUBJECT:", subject)
+
             x = email.header.make_header(email.header.decode_header(msg["From"]))
             frm = str(x)
             logger.debug("DEBUG: FROM:", frm)
 
             if not re.search("do_not_reply@intuit.com", frm, re.IGNORECASE):
                 continue
-
-            x = email.header.make_header(email.header.decode_header(msg["Subject"]))
-            subject = str(x)
-            logger.debug("DEBUG: SUBJECT:", subject)
 
             if not re.search("Your Mint Account", subject, re.IGNORECASE):
                 continue

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -705,11 +705,11 @@ def password_page(driver, password):
     try:
         driver.find_element(
             By.CSS_SELECTOR,
-            '#iux-password-confirmation-password, #ius-sign-in-mfa-password-collection-current-password'
+            "#iux-password-confirmation-password, #ius-sign-in-mfa-password-collection-current-password",
         ).send_keys(password)
         driver.find_element(
             By.CSS_SELECTOR,
-            '#ius-sign-in-mfa-password-collection-continue-btn, [data-testid="passwordVerificationContinueButton"]'
+            '#ius-sign-in-mfa-password-collection-continue-btn, [data-testid="passwordVerificationContinueButton"]',
         ).submit()
     except (
         NoSuchElementException,

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -704,10 +704,12 @@ def password_page(driver, password):
     # password only sometimes after mfa
     try:
         driver.find_element(
-            By.CSS_SELECTOR, '#iux-password-confirmation-password, #ius-sign-in-mfa-password-collection-current-password'
+            By.CSS_SELECTOR,
+            '#iux-password-confirmation-password, #ius-sign-in-mfa-password-collection-current-password'
         ).send_keys(password)
         driver.find_element(
-            By.CSS_SELECTOR, '#ius-sign-in-mfa-password-collection-continue-btn, [data-testid="passwordVerificationContinueButton"]'
+            By.CSS_SELECTOR,
+            '#ius-sign-in-mfa-password-collection-continue-btn, [data-testid="passwordVerificationContinueButton"]'
         ).submit()
     except (
         NoSuchElementException,

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -116,6 +116,13 @@ def get_email_code(imap_account, imap_password, imap_server, imap_folder, delete
 
             msg = email.message_from_bytes(data[0][1])
 
+            x = email.header.make_header(email.header.decode_header(msg["From"]))
+            frm = str(x)
+            logger.debug("DEBUG: FROM:", frm)
+
+            if not re.search("do_not_reply@intuit.com", frm, re.IGNORECASE):
+                continue
+
             x = email.header.make_header(email.header.decode_header(msg["Subject"]))
             subject = str(x)
             logger.debug("DEBUG: SUBJECT:", subject)
@@ -376,8 +383,6 @@ def sign_in(
             bypass_passwordless_login_page(driver)
             if mfa_method is not None:
                 mfa_selection_page(driver, mfa_method)
-            else:
-                check_mfa_method(driver)
             mfa_page(
                 driver,
                 mfa_method,
@@ -580,23 +585,6 @@ def search_mfa_method(driver):
         except (NoSuchElementException, ElementNotInteractableException):
             logger.info("{} MFA Method Not Found".format(constants.MFA_METHOD_LABEL))
     return mfa_token_input, mfa_token_button, mfa_method
-
-
-def check_mfa_method(driver):
-    for method in MFA_METHODS:
-        try:
-            mfa_token_select = driver.find_element(
-                By.CSS_SELECTOR, method[SELECT_CSS_SELECTORS_LABEL]
-            )
-        except (NoSuchElementException, ElementNotInteractableException):
-            continue
-        mfa_token_select.click()
-        driver.implicitly_wait(20)  # seconds
-        mfa_token_input = driver.find_element(
-            By.CSS_SELECTOR, method[INPUT_CSS_SELECTORS_LABEL]
-        )
-        driver.implicitly_wait(1)  # seconds
-        break
 
 
 def set_mfa_method(driver, mfa_method):

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -117,7 +117,6 @@ def get_email_code(imap_account, imap_password, imap_server, imap_folder, delete
             msg = email.message_from_bytes(data[0][1])
 
             x = email.header.make_header(email.header.decode_header(msg["Subject"]))
-
             subject = str(x)
             logger.debug("DEBUG: SUBJECT:", subject)
 


### PR DESCRIPTION
New attributes were added to SELECT_CSS_SELECTORS_LABEL and SPAN_CSS_SELECTORS_LABEL in response to a new OTP selection page.

Mint sometimes sends the OTP with a MIME-encoded email. I added MIME decoding.

Since updating to Chrome 103, the script occasionally throws a WebDriverException when signing in which is now safely ignored.  According to Google, this is a known bug and the only fix is to downgrade to 102.

New attributes were added within the password_page function to handle a new password entry page.

This PR should fix some complaints about the runtime error "Login to Mint failed due to timeout in the Multifactor Method Loop".
