### PR TITLE
bump version to 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
     New feature work occurs in the 2.x release series and only supports the new Mint UI / endpoints.
     Please see the README for more information.
 
+2.6
+---
+- add support for accessing the Trend API endpoint (#480)
+- bump selenium-requests dependency version to resolve issues (#521)
+- attempt to show the reason for a login failure (#523)
+
 2.5
 ---
 - increase wait for account selection to fix login issues (#508)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     description="a screen-scraping API for Mint.com",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="2.5",
+    version="2.6",
     packages=["mintapi"],
     license="The MIT License",
     author="Michael Rooney",


### PR DESCRIPTION
Seems like a reasonable time to release due to the selenium-requests bump, as I saw a bunch of folks on issues / Discord installing the zip from main to fix it 😅 It will also be nice to have the better errors as well as Trends!

We can then release the filters as its own 2.7 or similar!