### PR TITLE
[FEATURE] - Add support for accessing Transactions/Search API Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,28 @@ As mentioned above, the Report Type is the type of report for which to generate 
 | 15         | Net Worth Over Time |
 | 16         | Net Income Over Time |
 
-#### Date Filter
+### Financial Data Transactions
 
-As mentioned above, the Date Filter is the date window for which to generate your trend analysis.  The supplied value must be one of the following enum values:
+If you want to provide a more granular filtering of your financial data transactions, you can select from a variety of search filters that are sent to Mint. 
+
+| Parameter         | Data Type          | Description  |
+| ----------------  | ------------------ | -----------  |
+| date_filter       | DateFilter.Options | The date window for which to filter your transactions. |
+| start_date        | Optional[str]      | An optional beginning date to your transaction filtering. |
+| end_date          | Optional[str]      | An optional ending date to your transaction filtering. |
+| category_ids      | List[str]          | An optional list of category IDs of transactions to include. |
+| tag_ids           | List[str]          | An optional list of tag IDs of transactions to include. |
+| descriptions      | List[str]          | An optional list of descriptions of transactions to include. |
+| account_ids       | List[str]          | An optional list of account IDs of transactions to include. |
+| match_all_filters | boolean            | Whether to match all supplied filters (True) or at least one (False) |
+| include_investment | boolean           | Whether to include those transactions that are associated with an Investment Account. |
+| remove_pending    | boolean            | Whether to remove those transactions that are still Pending. | 
+| limit             | int                | The page size of results. |
+| offset            | int                | The starting record of your results. |
+
+### Date Filters
+
+As mentioned above, the Date Filter is the date window for which to generate your trend analysis or for which to search transactions.  The supplied value must be one of the following enum values:
 
 | Enum Value | Description |
 | ---------- | ----------- |
@@ -185,7 +204,7 @@ As mentioned above, the Date Filter is the date window for which to generate you
 | 10         | All Time      |
 | 11         | Custom        |
 
-If you select a Custom Date Filter, then `start_date` and `end_date` are required fields.
+If you select a Custom Date Filter, then `start_date` and `end_date` are required fields.  Similarly, if you wish to use `start_date` and `end_date`, Custom Date Filter must be used.
 
 ### From Python
 
@@ -289,14 +308,15 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
 ```shell
     usage: mintapi [-h] [--session-path [SESSION_PATH]] [--accounts] [--investments]
                    [--beta] [--budgets | --budget_hist] [--net-worth]
-                   [--transactions] [--trends] [--credit-score] [--credit-report]
+                   [--credit-score] [--credit-report]
                    [--exclude-inquiries] [--exclude-accounts] [--exclude-utilization]
                    [--start-date [START_DATE]] [--end-date [END_DATE]]
                    [--limit] [--include-investment] [--show-pending]
                    [--format] [--filename FILENAME] [--keyring] [--headless]
                    [--mfa-method {sms,email,soft-token}]
                    [--categories] [--attention]
-                   [--trend-report-type] [--trend-date-filter]
+                   [--transactions] [--transaction-date-filter]
+                   [--trends] [--trend-report-type] [--trend-date-filter]
                    email [password]
 
     positional arguments:
@@ -323,6 +343,7 @@ Run it as a sub-process from your favorite language; `pip install mintapi` creat
       --exclude-utilization Used in conjunction with --credit-report, ignores credit utilization data.
       --net-worth           Retrieve net worth information
       --transactions, -t    Retrieve transactions
+      --transaction-date-filter The date window for which to filter your transactions.  Default is All Time.
       --trends              Retrieve trend data related to your financial information
       --trend-report-type   The type of report for which to generate trend analysis.  Default is Spending Over Time.
       --trend-date-filter   The date window for which to generate your trend analysis.  Default is This Month.

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ Mint supports providing some analysis of your financial data based on different 
 | ----------------  | ------------------ | -----------  |
 | report_type       | ReportView.Options | The type of report to generate. |
 | date_filter       | DateFilter.Options | The date window to analyze your trends. |
-| start_date        | Optional[str]      | An optional beginning date to your trend analysis. |
-| end_date          | Optional[str]      | An optional ending date to your trend analysis. |
+| start_date        | Optional[str]      | An optional beginning date (mm-dd-yy) to your trend analysis. |
+| end_date          | Optional[str]      | An optional ending date (mm-dd-yy) to your trend analysis. |
 | category_ids      | List[str]          | An optional list of category IDs to include in your trend analysis. |
 | tag_ids           | List[str]          | An optional list of tag IDs to include in your trend analysis. |
 | descriptions      | List[str]          | An optional list of descriptions to include in your trend analysis. |
@@ -174,8 +174,8 @@ If you want to provide a more granular filtering of your financial data transact
 | Parameter         | Data Type          | Description  |
 | ----------------  | ------------------ | -----------  |
 | date_filter       | DateFilter.Options | The date window for which to filter your transactions. |
-| start_date        | Optional[str]      | An optional beginning date to your transaction filtering. |
-| end_date          | Optional[str]      | An optional ending date to your transaction filtering. |
+| start_date        | Optional[str]      | An optional beginning date (mm-dd-yy) to your transaction filtering. |
+| end_date          | Optional[str]      | An optional ending date (mm-dd-yy) to your transaction filtering. |
 | category_ids      | List[str]          | An optional list of category IDs of transactions to include. |
 | tag_ids           | List[str]          | An optional list of tag IDs of transactions to include. |
 | descriptions      | List[str]          | An optional list of descriptions of transactions to include. |

--- a/mintapi/cli.py
+++ b/mintapi/cli.py
@@ -196,6 +196,13 @@ def parse_arguments(args):
             {"action": "store_true", "help": "Test imap login and retrieval."},
         ),
         (
+            ("--intuit-account",),
+            {
+                "default": None,
+                "help": "Specify an override of the default intuit account for accessing Mint",
+            },
+        ),
+        (
             ("--investments",),
             {
                 "action": "store_true",
@@ -456,6 +463,7 @@ def main():
         imap_password=imap_password,
         imap_server=options.imap_server,
         imap_folder=options.imap_folder,
+        intuit_account=options.intuit_account,
         wait_for_sync=not options.no_wait_for_sync,
         wait_for_sync_timeout=options.wait_for_sync_timeout,
         fail_if_stale=options.fail_if_stale,

--- a/mintapi/constants.py
+++ b/mintapi/constants.py
@@ -1,6 +1,9 @@
 JSON_FORMAT = "json"
 CSV_FORMAT = "csv"
 
+GET_METHOD = "GET"
+POST_METHOD = "POST"
+
 ACCOUNT_KEY = "Account"
 BILL_KEY = "Bill"
 BUDGET_KEY = "Budget"

--- a/mintapi/filters.py
+++ b/mintapi/filters.py
@@ -4,7 +4,8 @@ General Filters helper classes
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
-from typing import List
+from enum import Enum
+from typing import List, Optional, Union
 
 
 @dataclass
@@ -71,6 +72,51 @@ class TagNameFilter(MatchFilter):
 
     def to_dict(self):
         return {"type": "TagNameFilter", "tagName": self.value, "exclude": True}
+
+
+@dataclass
+class DateFilter:
+    class Options(Enum):
+        """
+        Date options were inspected from the UI by clicking through all the available views
+        """
+
+        LAST_7_DAYS = 1
+        LAST_14_DAYS = 2
+        THIS_MONTH = 3
+        LAST_MONTH = 4
+        LAST_3_MONTHS = 5
+        LAST_6_MONTHS = 6
+        LAST_12_MONTHS = 7
+        THIS_YEAR = 8
+        LAST_YEAR = 9
+        ALL_TIME = 10
+        CUSTOM = 11
+
+    date_filter: Union[Options, str]
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+
+    def __post_init__(self):
+        if isinstance(self.date_filter, str):
+            assert hasattr(self.Options, self.date_filter)
+        elif isinstance(self.date_filter, self.Options):
+            self.date_filter = self.date_filter.name
+        else:
+            raise ValueError(
+                "Date Filter must be one of allowed values in enum `DateFilter.Options"
+            )
+
+        if self.date_filter == self.Options.CUSTOM.name:
+            # validate required start and end dates
+            assert self.start_date is not None or self.end_date is not None
+
+    def to_dict(self):
+        filter_clause = {"dateFilter": {"type": self.date_filter}}
+        if self.date_filter == self.Options.CUSTOM.name:
+            filter_clause["dateFilter"]["startDate"] = self.start_date
+            filter_clause["dateFilter"]["endDate"] = self.end_date
+        return filter_clause
 
 
 @dataclass

--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -706,29 +706,41 @@ def submit_mfa_code(mfa_token_input, mfa_token_button, mfa_code):
 def account_selection_page(driver, intuit_account):
     # account selection screen -- if there are multiple accounts, select one
     try:
-        select_account = driver.find_element(By.ID, "ius-mfa-select-account-section")
-        if intuit_account is not None:
-            account_input = select_account.find_element(
-                By.XPATH,
-                "//label/span[text()='{}']/../preceding-sibling::input".format(
-                    intuit_account
-                ),
-            )
-
-            account_input.click()
         WebDriverWait(driver, 20).until(
             expected_conditions.presence_of_element_located(
                 (
                     By.CSS_SELECTOR,
-                    "[data-testid='SelectAccountContinueButton']",
+                    '[data-testid="SelectAccountForm"]',
                 )
             )
         )
-        mfa_code_submit = driver.find_element(
+        select_account = driver.find_element(
+            By.CSS_SELECTOR, '[data-testid="SelectAccountForm"]'
+        )
+        if intuit_account is not None:
+            account_input = select_account.find_element(
+                By.XPATH,
+                "//*/span[text()='{}']/../../../preceding-sibling::input".format(
+                    intuit_account
+                ),
+            )
+            # NOTE: We need to execute a script because simply using account_input.click()
+            #       results in ElementClickInterceptedException.
+            driver.execute_script("arguments[0].click()", account_input)
+
+        WebDriverWait(driver, 20).until(
+            expected_conditions.presence_of_element_located(
+                (
+                    By.CSS_SELECTOR,
+                    "#ius-sign-in-mfa-select-account-continue-btn, [data-testid='SelectAccountContinueButton']",
+                )
+            )
+        )
+        driver.find_element(
             By.CSS_SELECTOR,
             '#ius-sign-in-mfa-select-account-continue-btn, [data-testid="SelectAccountContinueButton"]',
         ).click()
-    except NoSuchElementException:
+    except (TimeoutException, NoSuchElementException):
         logger.info("Not on Account Selection Screen")
 
 

--- a/mintapi/transactions.py
+++ b/mintapi/transactions.py
@@ -1,0 +1,34 @@
+"""
+Transactions helper classes
+"""
+
+from dataclasses import dataclass
+from mintapi.filters import SearchFilter, DateFilter
+
+
+@dataclass
+class TransactionRequest:
+    """
+    Helper class to construct a transaction request payload
+
+    Parameters
+    ----------
+    object : _type_
+        _description_
+    """
+
+    date_filter: DateFilter
+    search_filters: SearchFilter
+    # NOTE: This is included even though it is not used so that we can keep a
+    #       general method in api.py for creating requests.
+    report_view: str = None
+    limit: int = 5000
+    offset: int = 0
+
+    def to_dict(self):
+        return {
+            **self.date_filter.to_dict(),
+            **self.search_filters.to_dict(),
+            "limit": self.limit,
+            "offset": self.offset,
+        }

--- a/mintapi/trends.py
+++ b/mintapi/trends.py
@@ -4,8 +4,8 @@ Trends helper classes
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Union
-from mintapi.filters import SearchFilter
+from typing import Union
+from mintapi.filters import SearchFilter, DateFilter
 
 
 @dataclass
@@ -53,52 +53,6 @@ class ReportView:
 
 
 @dataclass
-class DateFilter:
-    class Options(Enum):
-        """
-        Date options were inspected from the UI by clicking through all the available views
-        """
-
-        LAST_7_DAYS = 1
-        LAST_14_DAYS = 2
-        THIS_MONTH = 3
-        LAST_MONTH = 4
-        LAST_3_MONTHS = 5
-        LAST_6_MONTHS = 6
-        LAST_12_MONTHS = 7
-        THIS_YEAR = 8
-        LAST_YEAR = 9
-        ALL_TIME = 10
-        CUSTOM = 11
-
-    date_filter: Union[Options, str]
-    start_date: Optional[str] = None
-    end_date: Optional[str] = None
-
-    def __post_init__(self):
-        if isinstance(self.date_filter, str):
-            assert hasattr(self.Options, self.date_filter)
-        elif isinstance(self.date_filter, self.Options):
-            self.date_filter = self.date_filter.name
-        else:
-            raise ValueError(
-                "Date Filter must be one of allowed values in enum `DateFilter.Options"
-            )
-
-        if self.date_filter == self.Options.CUSTOM.name:
-            # validate required start and end dates
-            assert self.start_date is not None
-            assert self.end_date is not None
-
-    def to_dict(self):
-        filter_clause = {"dateFilter": {"type": self.date_filter}}
-        if self.date_filter == self.Options.CUSTOM.name:
-            filter_clause["dateFilter"]["startDate"] = self.start_date
-            filter_clause["dateFilter"]["endDate"] = self.end_date
-        return filter_clause
-
-
-@dataclass
 class TrendRequest:
     """
     Helper class to construct a trend request payload
@@ -109,9 +63,9 @@ class TrendRequest:
         _description_
     """
 
-    report_view: ReportView
     date_filter: DateFilter
     search_filters: SearchFilter
+    report_view: ReportView
     limit: int = 5000
     offset: int = 0
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -328,7 +328,7 @@ class MintApiTests(unittest.TestCase):
         self.assertTrue("createdDate" in account_data)
         self.assertTrue("lastUpdatedDate" in account_data)
 
-    @patch.object(mintapi.Mint, "_Mint__get_mint_endpoint")
+    @patch.object(mintapi.Mint, "_Mint__post_mint_endpoint")
     def test_get_transaction_data(self, mock_call_transactions_endpoint):
         mock_call_transactions_endpoint.return_value = transactions_example
         transaction_data = mintapi.Mint().get_transaction_data()[0]


### PR DESCRIPTION
So far in v2, we have had minimal transaction filtering because of the more complex API Endpoint layout.  However, thanks to the work of @eyadgaran, a lot of the legwork was done on how to best implement Filtering in API Requests.

This PR switches from the `Transactions` endpoint to the `Transactions/Search` endpoint and includes different types of filtering of transactions, such as:

* By Account ID
* By Category
* By Tag
* By Description
* By Date