### PR TITLE
Fix SMS MFA by adding additional CSS selector

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -66,7 +66,7 @@ MFA_METHODS = [
     },
     {
         constants.MFA_METHOD_LABEL: constants.MFA_VIA_SMS,
-        SELECT_CSS_SELECTORS_LABEL: "#ius-mfa-sms-otp-card-challenge",
+        SELECT_CSS_SELECTORS_LABEL: '#ius-mfa-sms-otp-card-challenge, [data-testid="challengePickerOption_SMS_OTP"]',
         INPUT_CSS_SELECTORS_LABEL: "#ius-mfa-confirm-code",
         SPAN_CSS_SELECTORS_LABEL: '[data-testid="VerifyOtpHeaderText"], #VerifyOtpHeader',
         BUTTON_CSS_SELECTORS_LABEL: '#ius-mfa-otp-submit-btn, [data-testid="VerifyOtpSubmitButton"]',


### PR DESCRIPTION
Fixing SMS MFA selection by adding `[data-testid="challengePickerOption_SMS_OTP"]` CSS selector.