### PR TITLE
[FIX] Clarify that initialize_serverless_chrome_driver is not provided with mintapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ docker run --rm --shm-size=2g ghcr.io/mintapi/mintapi mintapi john@example.com m
 
 #### AWS Lambda Environment
 
-AWS Lambda may need a [specific chrome driver with specific options](https://robertorocha.info/setting-up-a-selenium-web-scraper-on-aws-lambda-with-python/). You can initialize Mint with the pre-configured headless serverless chrome through the constructor:
+AWS Lambda may need a [specific chrome driver with specific options](https://robertorocha.info/setting-up-a-selenium-web-scraper-on-aws-lambda-with-python/). You can initialize Mint with your own pre-configured headless serverless chrome through a constructor:
 
 
 ```python


### PR DESCRIPTION
I was confused by the wording on the README that there was a preconfigured method that `initialize_serverless_chrome_driver` was provided but is actually a stub method as mentioned in #540 . So this PR is to clarify the language a bit to make it a bit more clear that this is not actually provided.
