### PR TITLE
[FIX] - Issue with date filters being ignored

### DIFF
--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -74,7 +74,7 @@ ENDPOINTS = {
 
 def convert_mmddyy_to_datetime(date):
     try:
-        newdate = datetime.strptime(date, "%m/%d/%y")
+        newdate = datetime.strptime(date, "%m/%d/%y").strftime("%Y-%m-%d")
     except (TypeError, ValueError):
         newdate = None
     return newdate

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -74,7 +74,7 @@ ENDPOINTS = {
 
 def convert_mmddyy_to_datetime(date):
     try:
-        newdate = datetime.strptime(date, "%m/%d/%y").strftime("%Y-%m-%d")
+        newdate = datetime.strptime(date, "%m/%d/%y")
     except (TypeError, ValueError):
         newdate = None
     return newdate
@@ -649,8 +649,8 @@ class Mint(object):
         return request(
             date_filter=DateFilter(
                 date_filter=date_filter,
-                start_date=convert_mmddyy_to_datetime(start_date),
-                end_date=convert_mmddyy_to_datetime(end_date),
+                start_date=convert_mmddyy_to_datetime(start_date).strftime("%Y-%m-%d"),
+                end_date=convert_mmddyy_to_datetime(end_date).strftime("%Y-%m-%d"),
             ),
             search_filters=SearchFilter(
                 match_all_filters=search_clauses if match_all_filters else [],

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -72,9 +72,9 @@ ENDPOINTS = {
 }
 
 
-def convert_mmddyy_to_datetime(date):
+def convert_mmddyy_to_yyyymmdd(date):
     try:
-        newdate = datetime.strptime(date, "%m/%d/%y")
+        newdate = datetime.strptime(date, "%m/%d/%y").strftime("%Y-%m-%d")
     except (TypeError, ValueError):
         newdate = None
     return newdate
@@ -649,8 +649,8 @@ class Mint(object):
         return request(
             date_filter=DateFilter(
                 date_filter=date_filter,
-                start_date=convert_mmddyy_to_datetime(start_date).strftime("%Y-%m-%d"),
-                end_date=convert_mmddyy_to_datetime(end_date).strftime("%Y-%m-%d"),
+                start_date=convert_mmddyy_to_yyyymmdd(start_date),
+                end_date=convert_mmddyy_to_yyyymmdd(end_date),
             ),
             search_filters=SearchFilter(
                 match_all_filters=search_clauses if match_all_filters else [],


### PR DESCRIPTION
This PR should address issue #556 where the date filters are being ignored. The format on mint has the start and end dates a string in the format of "YYYY-MM-DD" but mintapi had been passing them as datetime objects which does not serialize when converting to a dictionary.

This can be test manually providing the DateFilter.Options.CUSTOM as the date_filter and start and end date. There should not be any transactions outside of the provided date range.

For example:
```
    client = mintapi.Mint(username, password)
    data = client.get_transaction_data(date_filter=DateFilter.Options.CUSTOM, start_date='01/01/18',
                                       end_date='12/31/18')
```
 