### PR TITLE
Add quit_driver_on_fail flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,11 @@ make calls to retrieve account/budget information.  We recommend using the
     wait_for_sync=False,  # do not wait for accounts to sync
     wait_for_sync_timeout=300,  # number of seconds to wait for sync
     fail_if_stale=True, # True will raise an exception if Mint is unable to refresh your data.
-	use_chromedriver_on_path=False,  # True will use a system provided chromedriver binary that
+	  use_chromedriver_on_path=False,  # True will use a system provided chromedriver binary that
 	                                 # is on the PATH (instead of downloading the latest version)
-    driver=None        # pre-configured driver. If None, Mint will initialize the WebDriver.
+    driver=None,        # pre-configured driver. If None, Mint will initialize the WebDriver.
+    quit_driver_on_fail=True  # Quit from the browser and driver if an unexpected exception caught.
+                              # Could be useful to set it to False if the ownership of the driver should not be owned by Mint object.
   )
 
   # Get account information

--- a/mintapi/api.py
+++ b/mintapi/api.py
@@ -114,9 +114,11 @@ class Mint(object):
         chromedriver_download_path=os.getcwd(),
         driver=None,
         beta=False,
+        quit_driver_on_fail=True,
     ):
         self.driver = None
         self.status_message = None
+        self.quit_driver_on_fail = quit_driver_on_fail
 
         if email and password:
             self.login_and_get_token(
@@ -212,8 +214,9 @@ class Mint(object):
         except Exception as e:
             msg = f"Could not sign in to Mint. Current page: {self.driver.current_url}"
             logger.exception(e)
-            self.driver.quit()
-            self.driver = None
+            if self.quit_driver_on_fail:
+                self.driver.quit()
+                self.driver = None
             raise Exception(msg) from e
 
     def get_attention(self):


### PR DESCRIPTION
Add the option to not quit the `webdriver` when an exception happens. Usecase: when there is an exception through the login process I would like to take a screenshot and save the HTML file for debugging purposes but I cannot as `Mint` always closes the driver.