### PR TITLE
Add new chromium headless flag

### DIFF
--- a/mintapi/signIn.py
+++ b/mintapi/signIn.py
@@ -300,6 +300,7 @@ def _create_web_driver_at_mint_com(
     chrome_options = ChromeOptions()
     if headless:
         chrome_options.add_argument("headless")
+        chrome_options.add_argument("headless=new")
         chrome_options.add_argument("no-sandbox")
         chrome_options.add_argument("disable-dev-shm-usage")
         chrome_options.add_argument("disable-gpu")


### PR DESCRIPTION
Update chromium flag to use new headless flag.

NOTE: Tested only on chromium driver that supports the new argument, unsure if there should be an actual selection depending on chromium version, expectation would be that chromium probably ignores unknown flags in older versions (nut needs to be tested).