### PR TITLE
[CHORE] - Update Mint constructor tests

### DIFF
--- a/tests/test_client_router.py
+++ b/tests/test_client_router.py
@@ -17,10 +17,21 @@ from mintapi.rest import RESTClient
 
 class MintApiTests(unittest.TestCase):
     @patch("mintapi.api.SeleniumBrowser")
-    def test_constructor_browser(self, mock_browser_class):
+    def test_constructor_browser_with_kwargs(self, mock_browser_class):
+        """
+        if use_rest_client = False the email and password keyword arguments
+        are passed to the browser
+        """
+        email = "your_email@web.com"
+        password = "password"
+        Mint(email=email, password=password, use_rest_client=False)
+        mock_browser_class.assert_called_once_with(email=email, password=password)
+
+    @patch("mintapi.api.SeleniumBrowser")
+    def test_constructor_browser_with_args(self, mock_browser_class):
         """
         if use_rest_client = False the email and password positional arguments
-        are passed to the browser to maintain backwards compatibility
+        are passed to the browser
         """
         email = "your_email@web.com"
         password = "password"
@@ -28,15 +39,25 @@ class MintApiTests(unittest.TestCase):
         mock_browser_class.assert_called_once_with(email=email, password=password)
 
     @patch("mintapi.api.SeleniumBrowser")
-    def test_constructor_rest(self, mock_browser_class):
+    def test_constructor_rest_client_with_kwargs(self, mock_browser_class):
         """
-        if use_rest_client = True the email and password positional arguments are
-        passed to the browser to maintain backwards compatibility
+        if use_rest_client = True the email and password keyword arguments
+        are passed to the browser
         """
         email = "your_email@web.com"
         password = "password"
         Mint(email=email, password=password, use_rest_client=True)
         mock_browser_class.assert_called_once_with(email=email, password=password)
+
+    @patch("mintapi.api.SeleniumBrowser")
+    def test_constructor_rest_client_with_args(self, mock_browser_class):
+        """
+        if use_rest_client = True the email and password positional arguments
+        are passed to the browser
+        """
+        email = "your_email@web.com"
+        password = "password"
+        Mint(email, password, use_rest_client=True)
         mock_browser_class.assert_called_once_with(email=email, password=password)
 
     def test_fallback_browser_only(self):


### PR DESCRIPTION
This PR updates the Mint constructor tests for both the rest client and browser client when using positional arguments and keyword arguments.

It tests the 4 different possibilities for passing the username and email into the mint constructor are:

Keyword arguments using the rest client
Positional arguments using the rest client
Keyword arguments using the browser client
Positional arguments using the browser client

My previous PR which added these tests were not testing all four possibilities.